### PR TITLE
Add stdin fuzzing capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ This phase focuses on analyzing the collected data to identify unique and intere
 
 ## Basic Usage
 
-Run the scaffolding entry point to start the fuzzer:
+Run the scaffolding entry point to start the fuzzer. The fuzzer sends random
+bytes to the target's standard input on each iteration:
 
 ```bash
-python3 main.py --target /path/to/binary --iterations 1000
+python3 main.py --target /path/to/binary --iterations 1000 --input-size 64
 ```
 
 This main script is minimal and will evolve alongside the project's features.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import argparse
 import logging
+import os
+import subprocess
 
 class Fuzzer:
     """Base fuzzer scaffold."""
@@ -7,16 +9,43 @@ class Fuzzer:
     def __init__(self):
         pass
 
+    def _run_once(self, target, data, timeout):
+        """Execute target with the provided input data."""
+        try:
+            result = subprocess.run(
+                [target], input=data, capture_output=True, timeout=timeout
+            )
+            logging.debug("Return code: %d", result.returncode)
+        except subprocess.TimeoutExpired:
+            logging.warning("Execution timed out")
+
     def run(self, args):
-        logging.info("Running fuzzer stub")
+        logging.info("Running stdin fuzzer")
         logging.info("Target: %s", args.target)
         logging.info("Iterations: %d", args.iterations)
+
+        for i in range(args.iterations):
+            data = os.urandom(args.input_size)
+            logging.debug("Iteration %d sending %d bytes", i, len(data))
+            self._run_once(args.target, data, args.timeout)
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="fz - a lightweight Python fuzzer")
     parser.add_argument("--target", required=True, help="Path to target binary or script")
     parser.add_argument("--iterations", type=int, default=1, help="Number of test iterations to run")
+    parser.add_argument(
+        "--input-size",
+        type=int,
+        default=256,
+        help="Number of random bytes to send to the target's stdin",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=1.0,
+        help="Seconds to wait for the target before killing it",
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
## Summary
- allow specifying number of random bytes to send to target stdin
- run target process with that data each iteration
- document new usage in README

## Testing
- `python3 main.py --help`
- `python3 main.py --target /bin/cat --iterations 2 --input-size 10`
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68431f520240832692f91cf9380faebc