### PR TITLE
Add ptrace coverage collection and corpus manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,12 @@ To send input via a file instead of stdin:
 python3 main.py --target /path/to/binary --iterations 1000 --file-input
 ```
 
+Coverage is gathered automatically using `ptrace`. Inputs that execute new
+basic blocks are stored in the corpus directory. Use `--corpus-dir` to change
+where these inputs are saved:
+
+```bash
+python3 main.py --target /path/to/binary --iterations 100 --corpus-dir ./out
+```
+
 This main script is minimal and will evolve alongside the project's features.

--- a/corpus.py
+++ b/corpus.py
@@ -1,0 +1,22 @@
+import hashlib
+import os
+
+
+class Corpus:
+    """Store inputs that produce new coverage."""
+
+    def __init__(self, directory="corpus"):
+        self.directory = directory
+        os.makedirs(directory, exist_ok=True)
+        self.coverage = set()
+
+    def save_if_interesting(self, data, coverage):
+        """Persist input if it triggers previously unseen coverage."""
+        if not coverage - self.coverage:
+            return False
+        self.coverage.update(coverage)
+        fname = hashlib.sha1(data).hexdigest()
+        path = os.path.join(self.directory, fname)
+        with open(path, "wb") as f:
+            f.write(data)
+        return True

--- a/coverage.py
+++ b/coverage.py
@@ -1,0 +1,79 @@
+import ctypes
+import ctypes.util
+import os
+
+libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
+
+PTRACE_ATTACH = 16
+PTRACE_DETACH = 17
+PTRACE_CONT = 7
+PTRACE_SINGLESTEP = 9
+PTRACE_GETREGS = 12
+
+class user_regs_struct(ctypes.Structure):
+    _fields_ = [
+        ("r15", ctypes.c_ulonglong),
+        ("r14", ctypes.c_ulonglong),
+        ("r13", ctypes.c_ulonglong),
+        ("r12", ctypes.c_ulonglong),
+        ("rbp", ctypes.c_ulonglong),
+        ("rbx", ctypes.c_ulonglong),
+        ("r11", ctypes.c_ulonglong),
+        ("r10", ctypes.c_ulonglong),
+        ("r9", ctypes.c_ulonglong),
+        ("r8", ctypes.c_ulonglong),
+        ("rax", ctypes.c_ulonglong),
+        ("rcx", ctypes.c_ulonglong),
+        ("rdx", ctypes.c_ulonglong),
+        ("rsi", ctypes.c_ulonglong),
+        ("rdi", ctypes.c_ulonglong),
+        ("orig_rax", ctypes.c_ulonglong),
+        ("rip", ctypes.c_ulonglong),
+        ("cs", ctypes.c_ulonglong),
+        ("eflags", ctypes.c_ulonglong),
+        ("rsp", ctypes.c_ulonglong),
+        ("ss", ctypes.c_ulonglong),
+        ("fs_base", ctypes.c_ulonglong),
+        ("gs_base", ctypes.c_ulonglong),
+        ("ds", ctypes.c_ulonglong),
+        ("es", ctypes.c_ulonglong),
+        ("fs", ctypes.c_ulonglong),
+        ("gs", ctypes.c_ulonglong),
+    ]
+
+
+libc.ptrace.argtypes = [ctypes.c_uint, ctypes.c_uint, ctypes.c_void_p, ctypes.c_void_p]
+libc.ptrace.restype = ctypes.c_long
+
+def _ptrace(request, pid, addr=0, data=0):
+    res = libc.ptrace(request, pid, ctypes.c_void_p(addr), ctypes.c_void_p(data))
+    if res != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return res
+
+
+def collect_coverage(pid):
+    """Attach to an existing process and record executed instruction pointers."""
+    coverage = set()
+    _ptrace(PTRACE_ATTACH, pid)
+    os.waitpid(pid, 0)
+    regs = user_regs_struct()
+    while True:
+        try:
+            _ptrace(PTRACE_GETREGS, pid, 0, ctypes.addressof(regs))
+            coverage.add(regs.rip)
+        except OSError:
+            break
+        try:
+            _ptrace(PTRACE_SINGLESTEP, pid)
+        except OSError:
+            break
+        wpid, status = os.waitpid(pid, 0)
+        if os.WIFEXITED(status) or os.WIFSIGNALED(status):
+            break
+    try:
+        _ptrace(PTRACE_DETACH, pid)
+    except OSError:
+        pass
+    return coverage


### PR DESCRIPTION
## Summary
- add `coverage.py` that collects basic block coverage using `ptrace`
- track coverage for each run inside `Fuzzer` and store interesting inputs using new `Corpus` class
- expose `--corpus-dir` CLI option
- document new behaviour in the README

## Testing
- `python3 -m py_compile coverage.py corpus.py main.py`
- `python3 main.py --help`
- `python3 main.py --target /bin/true --iterations 1 --timeout 0.1`

------
https://chatgpt.com/codex/tasks/task_e_684322220da083269f99950b4e9a3828