### PR TITLE
Add configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,25 @@ For UDP services:
 python3 main.py --target /path/to/server \
     --udp-host 127.0.0.1 --udp-port 9999 --iterations 100
 ```
+
+## Using a Configuration File
+
+All command line options can be provided in a YAML file. The keys in the file
+must match the command line option names. Pass the file with `--config` and any
+CLI arguments will override the values from the file.
+
+Example `config.yaml`:
+
+```yaml
+target: /path/to/binary
+iterations: 1000
+input_size: 128
+timeout: 2
+file_input: true
+```
+
+Run the fuzzer using this configuration:
+
+```bash
+python3 main.py --config config.yaml
+```


### PR DESCRIPTION
## Summary
- allow arguments to be supplied via YAML with `--config`
- merge config options with CLI flags
- document config files in README

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68483830dd4c8326811fa380e700944b