### PR TITLE
Prevent conflicting input options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,17 @@ This phase focuses on analyzing the collected data to identify unique and intere
 
 Run the scaffolding entry point to start the fuzzer. The fuzzer sends random
 bytes to the target's standard input on each iteration by default. Use
-`--file-input` to supply the bytes via a temporary file passed as an argument
+`file` subcommand to supply the bytes via a temporary file passed as an argument
 to the target:
 
 ```bash
 python3 main.py --target /path/to/binary --iterations 1000 --input-size 64
 ```
 
-To send input via a file instead of stdin:
+To send input via a file instead of stdin use the `file` subcommand:
 
 ```bash
-python3 main.py --target /path/to/binary --iterations 1000 --file-input
+python3 main.py file --target /path/to/binary --iterations 1000
 ```
 
 Coverage is gathered automatically using `ptrace`. Inputs that execute new
@@ -106,13 +106,11 @@ The fuzzer can also target network servers. Provide the host and port of the
 service and whether to use TCP or UDP:
 
 ```bash
-python3 main.py --target /path/to/server \
-    --tcp-host 127.0.0.1 --tcp-port 9999 --iterations 100
+python3 main.py tcp 127.0.0.1 9999 --target /path/to/server --iterations 100
 ```
 
 For UDP services:
 
 ```bash
-python3 main.py --target /path/to/server \
-    --udp-host 127.0.0.1 --udp-port 9999 --iterations 100
+python3 main.py udp 127.0.0.1 9999 --target /path/to/server --iterations 100
 ```

--- a/main.py
+++ b/main.py
@@ -88,20 +88,40 @@ def parse_args():
         help="Seconds to wait for the target before killing it",
     )
     parser.add_argument(
-        "--file-input",
-        action="store_true",
-        help="Write input to a temporary file and pass its path to the target",
-    )
-    parser.add_argument(
         "--corpus-dir",
         default="corpus",
         help="Directory to store interesting test cases",
     )
-    parser.add_argument("--tcp-host", help="Host to connect to via TCP")
-    parser.add_argument("--tcp-port", type=int, help="Port for TCP connection")
-    parser.add_argument("--udp-host", help="Host to send UDP packets to")
-    parser.add_argument("--udp-port", type=int, help="Port for UDP packets")
-    return parser.parse_args()
+
+    subparsers = parser.add_subparsers(dest="mode", help="Input method")
+
+    file_p = subparsers.add_parser(
+        "file", help="Write input to a temporary file and pass its path to the target"
+    )
+    file_p.set_defaults(file_input=True)
+
+    tcp_p = subparsers.add_parser("tcp", help="Send input over TCP to a service")
+    tcp_p.add_argument("tcp_host", help="Host to connect to via TCP")
+    tcp_p.add_argument("tcp_port", type=int, help="Port for TCP connection")
+
+    udp_p = subparsers.add_parser("udp", help="Send input over UDP to a service")
+    udp_p.add_argument("udp_host", help="Host to send UDP packets to")
+    udp_p.add_argument("udp_port", type=int, help="Port for UDP packets")
+
+    args = parser.parse_args()
+
+    if getattr(args, "mode", None) != "file":
+        args.file_input = False
+
+    if args.mode != "tcp":
+        args.tcp_host = None
+        args.tcp_port = None
+
+    if args.mode != "udp":
+        args.udp_host = None
+        args.udp_port = None
+
+    return args
 
 
 def main():


### PR DESCRIPTION
## Summary
- validate arg parsing using argparse subcommands
- update docs to show new `file`, `tcp`, and `udp` subcommands

## Testing
- `python3 -m py_compile main.py corpus.py coverage.py network_harness.py`
- `python3 main.py --target /bin/true tcp 127.0.0.1 1` *(fails as expected)*
- `python3 main.py --target /bin/true --iterations 1 file`

------
https://chatgpt.com/codex/tasks/task_e_6843293a38708326b363ba757747ace4