### PR TITLE
Add debug logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ python3 main.py --target /path/to/binary --iterations 100 --corpus-dir ./out
 ```
 
 This main script is minimal and will evolve alongside the project's features.
+Use `--debug` to enable verbose debug logging.
 
 ## Fuzzing a Network Service
 

--- a/main.py
+++ b/main.py
@@ -131,6 +131,11 @@ def parse_args():
         default="corpus",
         help="Directory to store interesting test cases",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
 
     # Verify config keys match existing parser options and set them as defaults
     if config_data:
@@ -149,8 +154,9 @@ def parse_args():
 
 
 def main():
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
     args = parse_args()
+    level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(message)s")
     fuzzer = Fuzzer(args.corpus_dir)
     fuzzer.run(args)
 


### PR DESCRIPTION
## Summary
- add a --debug flag to enable debug logs via argparse
- respect --debug when configuring logging
- document debug option in README

## Testing
- `python3 -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68484be83e688326966b3f361bf17a55