### PR TITLE
Implement block coverage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ python3 main.py --target /path/to/binary --iterations 1000 --file-input
 
 Coverage is gathered automatically using `ptrace`. Inputs that execute new
 basic blocks are stored in the corpus directory. Use `--corpus-dir` to change
-where these inputs are saved:
+where these inputs are saved. For faster coverage, enable breakpoint-based
+basic block tracking with `--block-coverage`:
 
 ```bash
-python3 main.py --target /path/to/binary --iterations 100 --corpus-dir ./out
+python3 main.py --target /path/to/binary --iterations 100 --corpus-dir ./out --block-coverage
 ```
 
 This main script is minimal and will evolve alongside the project's features.

--- a/network_harness.py
+++ b/network_harness.py
@@ -9,10 +9,11 @@ import coverage
 class NetworkHarness:
     """Launch a network service target and interact with it over TCP/UDP."""
 
-    def __init__(self, host="127.0.0.1", port=0, udp=False):
+    def __init__(self, host="127.0.0.1", port=0, udp=False, block_coverage=False):
         self.host = host
         self.port = port
         self.udp = udp
+        self.block_coverage = block_coverage
 
     def run(self, target, data, timeout):
         """Start the target, send bytes over the network, and collect coverage."""
@@ -34,7 +35,7 @@ class NetworkHarness:
         try:
             sock.sendall(data)
             sock.close()
-            coverage_set = coverage.collect_coverage(proc.pid)
+            coverage_set = coverage.collect_coverage(proc.pid, self.block_coverage)
             try:
                 proc.wait(timeout=timeout)
             except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Summary
- add optional breakpoint-based coverage that tracks basic blocks
- support `--block-coverage` in CLI and pass flag through network harness
- document how to enable block coverage in `README.md`

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68484ed6aaac8326860191cc1c68258d