### PR TITLE
Add debug logs and performance metric

### DIFF
--- a/corpus.py
+++ b/corpus.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import logging
 
 
 class Corpus:
@@ -13,10 +14,12 @@ class Corpus:
     def save_if_interesting(self, data, coverage):
         """Persist input if it triggers previously unseen coverage."""
         if not coverage - self.coverage:
+            logging.debug("Input did not yield new coverage")
             return False
         self.coverage.update(coverage)
         fname = hashlib.sha1(data).hexdigest()
         path = os.path.join(self.directory, fname)
         with open(path, "wb") as f:
             f.write(data)
+        logging.debug("Saved interesting input to %s", path)
         return True


### PR DESCRIPTION
## Summary
- add debug logging in coverage collection, corpus management and network harness
- log debug info when launching targets
- compute and log iterations per second after fuzzing run

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --target /bin/true --iterations 1 --debug` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684850c0bf208326b26edb3d56d9a5aa