### PR TITLE
Improve coverage debug logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ class Fuzzer:
         coverage_set = set()
         if network:
             coverage_set = network.run(target, data, timeout)
+            logging.debug("Network run returned %d coverage entries", len(coverage_set))
             self.corpus.save_if_interesting(data, coverage_set)
             return
         try:
@@ -50,6 +51,7 @@ class Fuzzer:
 
             logging.debug("Collecting coverage from pid %d", proc.pid)
             coverage_set = coverage.collect_coverage(proc.pid, self.block_coverage)
+            logging.debug("Collected %d coverage entries", len(coverage_set))
             try:
                 proc.wait(timeout=timeout)
             except subprocess.TimeoutExpired:

--- a/network_harness.py
+++ b/network_harness.py
@@ -40,6 +40,7 @@ class NetworkHarness:
             sock.sendall(data)
             sock.close()
             coverage_set = coverage.collect_coverage(proc.pid, self.block_coverage)
+            logging.debug("Collected %d coverage entries", len(coverage_set))
             try:
                 proc.wait(timeout=timeout)
             except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Summary
- add detailed logging when parsing basic blocks
- log ptrace requests and breakpoint operations
- log coverage entry counts in harness and main

## Testing
- `python3 -m py_compile coverage.py network_harness.py main.py corpus.py`
- `python3 main.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68485322b77883269ee17164e8ce5f54