### PR TITLE
Fix stdin BrokenPipe errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENT Instructions
+
+## Recommended Testing
+Before submitting changes, run the following sanity checks:
+
+```bash
+python3 -m py_compile *.py
+python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --block-coverage --iterations 1
+python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --block-coverage --iterations 2  # optional sanity check
+```
+
+This verifies bytecode compilation and exercises block coverage mode using a known system binary.

--- a/main.py
+++ b/main.py
@@ -46,8 +46,15 @@ class Fuzzer:
             )
 
             if not file_input and proc.stdin:
-                proc.stdin.write(data)
-                proc.stdin.close()
+                try:
+                    proc.stdin.write(data)
+                except BrokenPipeError:
+                    logging.debug("Stdin pipe closed before data was written")
+                finally:
+                    try:
+                        proc.stdin.close()
+                    except BrokenPipeError:
+                        logging.debug("Broken pipe when closing stdin")
 
             logging.debug("Collecting coverage from pid %d", proc.pid)
             coverage_set = coverage.collect_coverage(proc.pid, self.block_coverage)


### PR DESCRIPTION
## Summary
- avoid losing close attempt when stdin pipe already closed
- document recommended test command in AGENTS.md
- mention optional multi-iteration sanity check

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --block-coverage --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --block-coverage --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_684859de115083269b6c8c6c08c9a8bd