### PR TITLE
Remove instruction tracing option entirely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ Before submitting changes, run the following sanity checks:
 
 ```bash
 python3 -m py_compile *.py
-python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --block-coverage --iterations 1
-python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --block-coverage --iterations 2  # optional sanity check
+python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --iterations 1
+python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --iterations 2  # optional sanity check
 ```
 
-This verifies bytecode compilation and exercises block coverage mode using a known system binary.
+This verifies bytecode compilation and exercises basic block coverage using a known system binary.

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ Coverage is gathered automatically using `ptrace`. The addresses recorded are
 normalized to the binary's load base so identical inputs yield identical
 coverage sets across runs. Inputs that execute new basic blocks are stored in
 the corpus directory. Use `--corpus-dir` to change
-where these inputs are saved. For faster coverage, enable breakpoint-based
-basic block tracking with `--block-coverage`:
+where these inputs are saved. Basic block coverage via breakpoints is always
+enabled.
 
 ```bash
-python3 main.py --target /path/to/binary --iterations 100 --corpus-dir ./out --block-coverage
+python3 main.py --target /path/to/binary --iterations 100 --corpus-dir ./out
 ```
 
 This main script is minimal and will evolve alongside the project's features.

--- a/main.py
+++ b/main.py
@@ -17,9 +17,8 @@ from network_harness import NetworkHarness
 class Fuzzer:
     """Base fuzzer scaffold with simple coverage tracking."""
 
-    def __init__(self, corpus_dir="corpus", block_coverage=False):
+    def __init__(self, corpus_dir="corpus"):
         self.corpus = Corpus(corpus_dir)
-        self.block_coverage = block_coverage
 
     def _run_once(self, target, data, timeout, file_input=False, network=None):
         """Execute target once and record coverage."""
@@ -57,7 +56,7 @@ class Fuzzer:
                         logging.debug("Broken pipe when closing stdin")
 
             logging.debug("Collecting coverage from pid %d", proc.pid)
-            coverage_set = coverage.collect_coverage(proc.pid, self.block_coverage)
+            coverage_set = coverage.collect_coverage(proc.pid)
             logging.debug("Collected %d coverage entries", len(coverage_set))
             try:
                 proc.wait(timeout=timeout)
@@ -75,11 +74,11 @@ class Fuzzer:
         harness = None
         if args.tcp:
             host, port = args.tcp
-            harness = NetworkHarness(host, int(port), udp=False, block_coverage=self.block_coverage)
+            harness = NetworkHarness(host, int(port), udp=False)
             mode = "tcp"
         elif args.udp:
             host, port = args.udp
-            harness = NetworkHarness(host, int(port), udp=True, block_coverage=self.block_coverage)
+            harness = NetworkHarness(host, int(port), udp=True)
             mode = "udp"
         logging.info("Running %s fuzzer", mode)
         logging.info("Target: %s", args.target)
@@ -157,11 +156,6 @@ def parse_args():
         help="Directory to store interesting test cases",
     )
     parser.add_argument(
-        "--block-coverage",
-        action="store_true",
-        help="Use breakpoint-based basic block coverage",
-    )
-    parser.add_argument(
         "--debug",
         action="store_true",
         help="Enable debug logging",
@@ -187,7 +181,7 @@ def main():
     args = parse_args()
     level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(message)s")
-    fuzzer = Fuzzer(args.corpus_dir, block_coverage=args.block_coverage)
+    fuzzer = Fuzzer(args.corpus_dir)
     fuzzer.run(args)
 
 

--- a/network_harness.py
+++ b/network_harness.py
@@ -9,11 +9,10 @@ import coverage
 class NetworkHarness:
     """Launch a network service target and interact with it over TCP/UDP."""
 
-    def __init__(self, host="127.0.0.1", port=0, udp=False, block_coverage=False):
+    def __init__(self, host="127.0.0.1", port=0, udp=False):
         self.host = host
         self.port = port
         self.udp = udp
-        self.block_coverage = block_coverage
 
     def run(self, target, data, timeout):
         """Start the target, send bytes over the network, and collect coverage."""
@@ -39,7 +38,7 @@ class NetworkHarness:
             logging.debug("Sending %d bytes", len(data))
             sock.sendall(data)
             sock.close()
-            coverage_set = coverage.collect_coverage(proc.pid, self.block_coverage)
+            coverage_set = coverage.collect_coverage(proc.pid)
             logging.debug("Collected %d coverage entries", len(coverage_set))
             try:
                 proc.wait(timeout=timeout)


### PR DESCRIPTION
## Summary
- drop the obsolete `--block-coverage` CLI option
- simplify coverage, fuzzer and harness APIs
- update README and agent instructions for new default

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_68485e60ffcc83269cb8a54e9d4121bb