### PR TITLE
Fix fuzzer hang on short-lived processes

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,18 @@ class Fuzzer:
                         logging.debug("Broken pipe when closing stdin")
 
             logging.debug("Collecting coverage from pid %d", proc.pid)
-            coverage_set = coverage.collect_coverage(proc.pid)
+            try:
+                coverage_set = coverage.collect_coverage(proc.pid, timeout)
+            except FileNotFoundError:
+                logging.debug(
+                    "Process %d exited before coverage collection", proc.pid
+                )
+                coverage_set = set()
+            except OSError as e:
+                logging.debug(
+                    "Failed to collect coverage from pid %d: %s", proc.pid, e
+                )
+                coverage_set = set()
             logging.debug("Collected %d coverage entries", len(coverage_set))
             try:
                 proc.wait(timeout=timeout)

--- a/network_harness.py
+++ b/network_harness.py
@@ -38,7 +38,7 @@ class NetworkHarness:
             logging.debug("Sending %d bytes", len(data))
             sock.sendall(data)
             sock.close()
-            coverage_set = coverage.collect_coverage(proc.pid)
+            coverage_set = coverage.collect_coverage(proc.pid, timeout)
             logging.debug("Collected %d coverage entries", len(coverage_set))
             try:
                 proc.wait(timeout=timeout)


### PR DESCRIPTION
## Summary
- catch failures when collecting coverage so quick-exiting targets don't hang
- add timeout-aware coverage collection
- pass target timeout into coverage collector

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_6848642c13f88326a000641b4ab29e98