### PR TITLE
Switch timeout log to info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ Before submitting changes, run the following sanity checks:
 
 ```bash
 python3 -m py_compile *.py
-python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --iterations 1
-python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --debug --iterations 2  # optional sanity check
+python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1
+python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2  # optional sanity check
 ```
 
 This verifies bytecode compilation and exercises basic block coverage using a known system binary.

--- a/coverage.py
+++ b/coverage.py
@@ -178,7 +178,7 @@ def collect_coverage(pid, timeout=1.0):
             break
         if wpid == 0:
             if time.time() > end_time:
-                logging.debug("Coverage wait timed out")
+                logging.info("Coverage wait timed out")
                 break
             time.sleep(0.01)
             continue


### PR DESCRIPTION
## Summary
- log coverage timeout events at INFO level
- remove `--debug` flag from recommended tests in `AGENTS.md`

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_68486ebbe74c8326a453397083c7e33b