### PR TITLE
Add corpus loading on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,11 @@ python3 main.py --target /path/to/binary --iterations 1000 --file-input
 Coverage is gathered automatically using `ptrace`. The addresses recorded are
 normalized to the binary's load base so identical inputs yield identical
 coverage sets across runs. Inputs that execute new basic blocks are stored in
-the corpus directory. Use `--corpus-dir` to change
-where these inputs are saved. Basic block coverage via breakpoints is always
-enabled.
+the corpus directory. Each saved input is written to `<hash>.bin` and a
+corresponding `<hash>.json` metadata file contains the sequence of executed
+basic blocks. Existing corpus files are loaded automatically so coverage
+from previous runs is preserved. Use `--corpus-dir` to change where these
+inputs are saved. Basic block coverage via breakpoints is always enabled.
 
 ```bash
 python3 main.py --target /path/to/binary --iterations 100 --corpus-dir ./out

--- a/corpus.py
+++ b/corpus.py
@@ -1,25 +1,48 @@
 import hashlib
+import json
 import os
 import logging
 
 
 class Corpus:
-    """Store inputs that produce new coverage."""
+    """Store inputs that produce new coverage along with execution traces."""
 
     def __init__(self, directory="corpus"):
         self.directory = directory
         os.makedirs(directory, exist_ok=True)
         self.coverage = set()
+        self._load_existing()
 
-    def save_if_interesting(self, data, coverage):
-        """Persist input if it triggers previously unseen coverage."""
+    def _load_existing(self):
+        """Load coverage information from an existing corpus directory."""
+        for name in os.listdir(self.directory):
+            if not name.endswith(".json"):
+                continue
+            path = os.path.join(self.directory, name)
+            try:
+                with open(path) as f:
+                    meta = json.load(f)
+                self.coverage.update(meta.get("blocks", []))
+            except (OSError, json.JSONDecodeError) as e:
+                logging.warning("Failed to load %s: %s", path, e)
+        if self.coverage:
+            logging.info(
+                "Loaded %d coverage entries from existing corpus", len(self.coverage)
+            )
+
+    def save_if_interesting(self, data, coverage, trace=None):
+        """Persist input and trace if it triggers previously unseen coverage."""
         if not coverage - self.coverage:
             logging.debug("Input did not yield new coverage")
             return False
         self.coverage.update(coverage)
         fname = hashlib.sha1(data).hexdigest()
-        path = os.path.join(self.directory, fname)
-        with open(path, "wb") as f:
+        bin_path = os.path.join(self.directory, fname + ".bin")
+        with open(bin_path, "wb") as f:
             f.write(data)
-        logging.debug("Saved interesting input to %s", path)
+        meta = {"blocks": trace if trace is not None else sorted(coverage)}
+        meta_path = os.path.join(self.directory, fname + ".json")
+        with open(meta_path, "w") as f:
+            json.dump(meta, f)
+        logging.debug("Saved interesting input to %s and %s", bin_path, meta_path)
         return True

--- a/main.py
+++ b/main.py
@@ -23,10 +23,13 @@ class Fuzzer:
     def _run_once(self, target, data, timeout, file_input=False, network=None):
         """Execute target once and record coverage."""
         coverage_set = set()
+        trace = []
         if network:
-            coverage_set = network.run(target, data, timeout)
-            logging.debug("Network run returned %d coverage entries", len(coverage_set))
-            self.corpus.save_if_interesting(data, coverage_set)
+            coverage_set, trace = network.run(target, data, timeout)
+            logging.debug(
+                "Network run returned %d coverage entries", len(coverage_set)
+            )
+            self.corpus.save_if_interesting(data, coverage_set, trace)
             return
         try:
             if file_input:
@@ -57,18 +60,24 @@ class Fuzzer:
 
             logging.debug("Collecting coverage from pid %d", proc.pid)
             try:
-                coverage_set = coverage.collect_coverage(proc.pid, timeout)
+                coverage_set, trace = coverage.collect_coverage(proc.pid, timeout)
             except FileNotFoundError:
                 logging.debug(
                     "Process %d exited before coverage collection", proc.pid
                 )
                 coverage_set = set()
+                trace = []
             except OSError as e:
                 logging.debug(
                     "Failed to collect coverage from pid %d: %s", proc.pid, e
                 )
                 coverage_set = set()
-            logging.debug("Collected %d coverage entries", len(coverage_set))
+                trace = []
+            logging.debug(
+                "Collected %d coverage entries with %d trace entries",
+                len(coverage_set),
+                len(trace),
+            )
             try:
                 proc.wait(timeout=timeout)
             except subprocess.TimeoutExpired:
@@ -78,7 +87,7 @@ class Fuzzer:
             if file_input:
                 os.unlink(filename)
 
-        self.corpus.save_if_interesting(data, coverage_set)
+        self.corpus.save_if_interesting(data, coverage_set, trace)
 
     def run(self, args):
         mode = "file" if args.file_input else "stdin"

--- a/network_harness.py
+++ b/network_harness.py
@@ -38,8 +38,12 @@ class NetworkHarness:
             logging.debug("Sending %d bytes", len(data))
             sock.sendall(data)
             sock.close()
-            coverage_set = coverage.collect_coverage(proc.pid, timeout)
-            logging.debug("Collected %d coverage entries", len(coverage_set))
+            coverage_set, trace = coverage.collect_coverage(proc.pid, timeout)
+            logging.debug(
+                "Collected %d coverage entries with %d trace entries",
+                len(coverage_set),
+                len(trace),
+            )
             try:
                 proc.wait(timeout=timeout)
             except subprocess.TimeoutExpired:
@@ -48,5 +52,7 @@ class NetworkHarness:
         finally:
             if proc.poll() is None:
                 proc.kill()
-        logging.debug("Network run complete with %d coverage entries", len(coverage_set))
-        return coverage_set
+        logging.debug(
+            "Network run complete with %d coverage entries", len(coverage_set)
+        )
+        return coverage_set, trace


### PR DESCRIPTION
## Summary
- load existing coverage info from corpus directory when fuzzer starts
- document automatic corpus loading in README

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_6848741376188326b63f7ac64fb4b5c5