### PR TITLE
Add parallel fuzzing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ To fuzz continuously until interrupted, use `--run-forever`:
 python3 main.py --target /path/to/binary --run-forever
 ```
 
+To run multiple fuzzing processes concurrently, use `--parallel`:
+
+```bash
+python3 main.py --target /path/to/binary --iterations 100 --parallel 4
+```
+
 Coverage is gathered automatically using `ptrace`. The addresses recorded are
 normalized to the binary's load base so identical inputs yield identical
 coverage sets across runs. Inputs that execute new basic blocks are stored in


### PR DESCRIPTION
## Summary
- add `--parallel` option to run multiple fuzzing processes
- implement worker routine in `main.py`
- document parallel usage in README

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1 --parallel 2`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2 --parallel 2`


------
https://chatgpt.com/codex/tasks/task_e_6848782a46cc8326ab5e7c79515b52a7