### PR TITLE
Improve fuzzing output and timeout handling

### DIFF
--- a/corpus.py
+++ b/corpus.py
@@ -21,5 +21,5 @@ class Corpus:
         path = os.path.join(self.directory, fname)
         with open(path, "wb") as f:
             f.write(data)
-        logging.debug("Saved interesting input to %s", path)
+        logging.info("Saved interesting input to %s", path)
         return True

--- a/coverage.py
+++ b/coverage.py
@@ -170,7 +170,7 @@ def collect_coverage(pid, timeout=1.0):
 
     _ptrace(PTRACE_CONT, pid)
     regs = user_regs_struct()
-    end_time = time.time() + timeout
+    end_time = time.time() + timeout * 2
     while True:
         try:
             wpid, status = os.waitpid(pid, os.WNOHANG)
@@ -178,7 +178,7 @@ def collect_coverage(pid, timeout=1.0):
             break
         if wpid == 0:
             if time.time() > end_time:
-                logging.info("Coverage wait timed out")
+                logging.debug("Coverage wait timed out")
                 break
             time.sleep(0.01)
             continue

--- a/main.py
+++ b/main.py
@@ -42,6 +42,8 @@ class Fuzzer:
             proc = subprocess.Popen(
                 argv,
                 stdin=subprocess.PIPE if not file_input else None,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
             )
 
             if not file_input and proc.stdin:

--- a/network_harness.py
+++ b/network_harness.py
@@ -17,7 +17,7 @@ class NetworkHarness:
     def run(self, target, data, timeout):
         """Start the target, send bytes over the network, and collect coverage."""
         logging.debug("Launching network target: %s", target)
-        proc = subprocess.Popen([target])
+        proc = subprocess.Popen([target], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         sock_type = socket.SOCK_DGRAM if self.udp else socket.SOCK_STREAM
         sock = socket.socket(socket.AF_INET, sock_type)
 


### PR DESCRIPTION
## Summary
- mute target stdout/stderr so only fuzzer logs appear
- extend coverage wait time and downgrade its timeout log to debug
- promote interesting sample messages to info level

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_684879c8cd0c8326861c6d80edbce85e