### PR TITLE
Store coverage with input

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ the corpus directory. Use `--corpus-dir` to change
 where these inputs are saved. Basic block coverage via breakpoints is always
 enabled.
 
+Each saved input is keyed by a hash of the coverage it produced. Samples are
+written as JSON files containing both the executed basic blocks and the input
+bytes (base64 encoded). Because filenames are derived from the coverage hash,
+parallel fuzzing only keeps the first input for a given coverage set,
+preventing duplicate samples that exercise the same code paths.
+
 ```bash
 python3 main.py --target /path/to/binary --iterations 100 --corpus-dir ./out
 ```

--- a/corpus.py
+++ b/corpus.py
@@ -1,6 +1,8 @@
 import hashlib
 import os
 import logging
+import json
+import base64
 
 
 class Corpus:
@@ -10,16 +12,32 @@ class Corpus:
         self.directory = directory
         os.makedirs(directory, exist_ok=True)
         self.coverage = set()
+        self.coverage_hashes = set()
 
     def save_if_interesting(self, data, coverage):
         """Persist input if it triggers previously unseen coverage."""
+        cov_hash = hashlib.sha1(
+            ",".join(str(c) for c in sorted(coverage)).encode()
+        ).hexdigest()
+        path = os.path.join(self.directory, cov_hash + ".json")
+
+        if cov_hash in self.coverage_hashes or os.path.exists(path):
+            logging.debug("Input with identical coverage already stored")
+            self.coverage.update(coverage)
+            return False
+
         if not coverage - self.coverage:
             logging.debug("Input did not yield new coverage")
+            self.coverage.update(coverage)
             return False
+
         self.coverage.update(coverage)
-        fname = hashlib.sha1(data).hexdigest()
-        path = os.path.join(self.directory, fname)
-        with open(path, "wb") as f:
-            f.write(data)
+        self.coverage_hashes.add(cov_hash)
+        record = {
+            "coverage": sorted(coverage),
+            "data": base64.b64encode(data).decode("ascii"),
+        }
+        with open(path, "w") as f:
+            json.dump(record, f)
         logging.info("Saved interesting input to %s", path)
         return True


### PR DESCRIPTION
## Summary
- save coverage data and input bytes together in a JSON file
- note the new JSON corpus format in the docs

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_68487b4815d08326b8638d9b40431bbc