### PR TITLE
Implement input minimization for crashing cases

### DIFF
--- a/corpus.py
+++ b/corpus.py
@@ -3,6 +3,9 @@ import os
 import logging
 import json
 import base64
+import time
+import tempfile
+import subprocess
 
 
 class Corpus:
@@ -41,3 +44,95 @@ class Corpus:
             json.dump(record, f)
         logging.info("Saved interesting input to %s", path)
         return True
+
+    def _save_failure(self, data: bytes, prefix: str) -> str:
+        """Save a crashing or timing-out input and return its path."""
+        os.makedirs(self.directory, exist_ok=True)
+        filename = f"{prefix}-{int(time.time() * 1000)}.bin"
+        path = os.path.join(self.directory, filename)
+        with open(path, "wb") as f:
+            f.write(data)
+        logging.info("Saved %s input to %s", prefix, path)
+        return path
+
+    def minimize_input(self, path: str, target: str, timeout: float = 1.0,
+                        file_input: bool = False, network=None) -> str:
+        """Minimize the crashing input saved at *path*.
+
+        The returned path points to the minimized input which is stored
+        alongside the original file.
+        """
+        try:
+            with open(path, "rb") as f:
+                data = f.read()
+        except OSError as e:
+            logging.debug("Failed to read %s for minimization: %s", path, e)
+            return path
+
+        def reproduces_crash(inp: bytes) -> bool:
+            if network:
+                _cov, crashed, timed_out = network.run(target, inp, timeout)
+                return crashed or timed_out
+            if file_input:
+                tmp = tempfile.NamedTemporaryFile(delete=False)
+                try:
+                    tmp.write(inp)
+                    tmp.flush()
+                    argv = [target, tmp.name]
+                    proc = subprocess.Popen(
+                        argv,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    try:
+                        proc.wait(timeout=timeout)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                        return True
+                    return proc.returncode not in (0, None)
+                finally:
+                    try:
+                        os.unlink(tmp.name)
+                    except OSError:
+                        pass
+            proc = subprocess.Popen(
+                [target],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if proc.stdin:
+                try:
+                    proc.stdin.write(inp)
+                except BrokenPipeError:
+                    pass
+                finally:
+                    try:
+                        proc.stdin.close()
+                    except BrokenPipeError:
+                        pass
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                return True
+            return proc.returncode not in (0, None)
+
+        minimal = data
+        step = len(minimal) // 2
+        while step > 0 and len(minimal) > 1:
+            reduced = minimal[: len(minimal) - step]
+            if reproduces_crash(reduced):
+                minimal = reduced
+            else:
+                step //= 2
+
+        if minimal == data:
+            logging.info("Input already minimal")
+            return path
+
+        min_path = path + ".min"
+        with open(min_path, "wb") as f:
+            f.write(minimal)
+        logging.info("Minimized input saved to %s", min_path)
+        return min_path


### PR DESCRIPTION
## Summary
- implement `Corpus.minimize_input` to shrink crashing inputs
- extend `NetworkHarness.run` to return crash/timeout info
- invoke minimization from `Fuzzer` when a crash or timeout is detected

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_6849841b74508326b8a17cc3daa8a1c3