### PR TITLE
Fix busy wait in coverage collection loop

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -243,7 +243,9 @@ def collect_coverage(pid, timeout=1.0, exe=None):
                         process.StepInstruction(False)
                     process.Continue()
                 else:
-                    time.sleep(0.01)
+                    # Yield execution briefly so the target process can run
+                    # without introducing a noticeable delay.
+                    time.sleep(0)
 
             process.Detach()
             lldb.SBDebugger.Destroy(dbg)
@@ -303,7 +305,10 @@ def collect_coverage(pid, timeout=1.0, exe=None):
             if time.time() > end_time:
                 logging.debug("Coverage wait timed out")
                 break
-            time.sleep(0.01)
+            # Yield to the scheduler so the traced process can continue
+            # executing without incurring the ~10ms delay from the previous
+            # implementation.
+            time.sleep(0)
             continue
         if os.WIFEXITED(status) or os.WIFSIGNALED(status):
             break


### PR DESCRIPTION
## Summary
- yield the CPU instead of sleeping for 10ms during coverage collection
- update macOS branch with the same improvement

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_684988482ac08326b216054d5d3ebe96