### PR TITLE
Capture target output in corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ where these inputs are saved. Basic block coverage via breakpoints is always
 enabled.
 
 Each saved input is keyed by a hash of the coverage it produced. Samples are
-written as JSON files containing both the executed basic blocks and the input
-bytes (base64 encoded). Because filenames are derived from the coverage hash,
+written as JSON files containing the executed basic blocks, the input bytes
+(base64 encoded), and optionally the first N bytes of stdout/stderr from the
+target. Use `--output-bytes` to set how much output to store. Because filenames
+are derived from the coverage hash,
 parallel fuzzing only keeps the first input for a given coverage set,
 preventing duplicate samples that exercise the same code paths.
 
@@ -165,6 +167,7 @@ input_size: 128
 timeout: 2
 file_input: true
 run_forever: true
+output_bytes: 1024
 ```
 
 Run the fuzzer using this configuration:

--- a/network_harness.py
+++ b/network_harness.py
@@ -2,6 +2,7 @@ import logging
 import socket
 import subprocess
 import time
+import tempfile
 
 import coverage
 
@@ -14,13 +15,15 @@ class NetworkHarness:
         self.port = port
         self.udp = udp
 
-    def run(self, target, data, timeout):
+    def run(self, target, data, timeout, output_bytes=0):
         """Start the target, send bytes over the network, and collect coverage.
 
-        Returns a tuple of (coverage_set, crashed, timed_out).
+        Returns a tuple of (coverage_set, crashed, timed_out, stdout, stderr).
         """
         logging.debug("Launching network target: %s", target)
-        proc = subprocess.Popen([target], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        stdout_file = tempfile.TemporaryFile()
+        stderr_file = tempfile.TemporaryFile()
+        proc = subprocess.Popen([target], stdout=stdout_file, stderr=stderr_file)
         sock_type = socket.SOCK_DGRAM if self.udp else socket.SOCK_STREAM
         sock = socket.socket(socket.AF_INET, sock_type)
 
@@ -55,5 +58,11 @@ class NetworkHarness:
         finally:
             if proc.poll() is None:
                 proc.kill()
+        stdout_file.seek(0)
+        stderr_file.seek(0)
+        stdout_data = stdout_file.read(output_bytes) if output_bytes else b""
+        stderr_data = stderr_file.read(output_bytes) if output_bytes else b""
+        stdout_file.close()
+        stderr_file.close()
         logging.debug("Network run complete with %d coverage entries", len(coverage_set))
-        return coverage_set, crashed, timed_out
+        return coverage_set, crashed, timed_out, stdout_data, stderr_data


### PR DESCRIPTION
## Summary
- store a limited amount of stdout/stderr in corpus files
- add `--output-bytes` CLI option
- propagate output limit through harnesses
- document new feature in README

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1 --output-bytes 10`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2 --output-bytes 10`


------
https://chatgpt.com/codex/tasks/task_e_684993151ee083268426115f3b1885aa