### PR TITLE
Enhance corpus_analyzer output

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ python3 main.py --config config.yaml
 ## Corpus Analysis
 
 Use `corpus_analyzer.py` to inspect the saved samples. The script prints the
-captured stdout and stderr for each entry in the corpus directory.
+captured stdout, stderr, and length of the input for each entry in the corpus
+directory.
 
 ```bash
 python3 corpus_analyzer.py --corpus-dir ./corpus

--- a/corpus_analyzer.py
+++ b/corpus_analyzer.py
@@ -37,6 +37,11 @@ def main() -> None:
     for path in _iter_samples(args.corpus_dir):
         with open(path) as f:
             record = json.load(f)
+        if "data" in record:
+            length = len(base64.b64decode(record["data"]))
+            print(f"== LENGTH OF INPUT from {os.path.basename(path)} ==")
+            print(length)
+            print()
         for key in ("stdout", "stderr"):
             if key in record:
                 print(f"== {key.upper()} from {os.path.basename(path)} ==")


### PR DESCRIPTION
## Summary
- add input length reporting for corpus entries
- document new corpus analyzer behaviour in README

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_6849b1c3dbc88326975c8f97aac57bae