### PR TITLE
Add multi-step mutation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ bytes to the target's standard input on each iteration by default. Use
 to the target:
 
 ```bash
-python3 main.py --target /path/to/binary --iterations 1000 --input-size 64
+python3 main.py --target /path/to/binary --iterations 1000 --input-size 64 --mutations 4
 ```
 
 To send input via a file instead of stdin:
@@ -131,8 +131,10 @@ Use `--debug` to enable verbose debug logging.
 Inputs are chosen from previously saved corpus files and mutated before being
 executed. The mutator weights seeds by the amount of coverage they produced and
 applies simple strategies such as bit flipping, splicing two seeds together,
-and inserting or deleting bytes. Whenever a run yields new coverage the input
-is added to the pool so future mutations build on the most interesting cases.
+and inserting or deleting bytes. Each new input can be mutated multiple times in
+sequence (controlled by `--mutations`), allowing combinations of these
+operations. Whenever a run yields new coverage the input is added to the pool so
+future mutations build on the most interesting cases.
 
 ## Fuzzing a Network Service
 
@@ -164,6 +166,7 @@ Example `config.yaml`:
 target: /path/to/binary
 iterations: 1000
 input_size: 128
+mutations: 2
 timeout: 2
 file_input: true
 run_forever: true

--- a/main.py
+++ b/main.py
@@ -145,7 +145,7 @@ class Fuzzer:
         start_time = time.time()
         i = 0
         from mutator import Mutator
-        mutator = Mutator(args.corpus_dir, args.input_size)
+        mutator = Mutator(args.corpus_dir, args.input_size, args.mutations)
         try:
             while True:
                 data = mutator.next_input()
@@ -220,6 +220,12 @@ def parse_args():
         type=int,
         default=256,
         help="Number of random bytes to send to the target's stdin",
+    )
+    parser.add_argument(
+        "--mutations",
+        type=int,
+        default=1,
+        help="Maximum number of mutation steps applied to each input",
     )
     parser.add_argument(
         "--timeout",

--- a/mutator.py
+++ b/mutator.py
@@ -8,9 +8,12 @@ from typing import List, Set
 class Mutator:
     """Basic mutation engine backed by saved corpus inputs."""
 
-    def __init__(self, corpus_dir: str = "corpus", input_size: int = 256) -> None:
+    def __init__(
+        self, corpus_dir: str = "corpus", input_size: int = 256, max_mutations: int = 1
+    ) -> None:
         self.corpus_dir = corpus_dir
         self.input_size = input_size
+        self.max_mutations = max(1, int(max_mutations))
         self.seeds: List[bytes] = []
         self.weights: List[int] = []
         self._load_corpus()
@@ -68,15 +71,18 @@ class Mutator:
         data = bytearray(seed)
         if not data:
             data.extend(os.urandom(1))
-        strategy = random.choice(["bitflip", "splice", "insert", "delete"])
-        if strategy == "bitflip":
-            data = self._bitflip(data)
-        elif strategy == "splice":
-            data = self._splice(data)
-        elif strategy == "insert":
-            data = self._insert(data)
-        else:  # delete
-            data = self._delete(data)
+        strategies = ["bitflip", "splice", "insert", "delete"]
+        steps = random.randint(1, self.max_mutations)
+        for _ in range(steps):
+            strategy = random.choice(strategies)
+            if strategy == "bitflip":
+                data = self._bitflip(data)
+            elif strategy == "splice":
+                data = self._splice(data)
+            elif strategy == "insert":
+                data = self._insert(data)
+            else:  # delete
+                data = self._delete(data)
 
         if len(data) > self.input_size:
             data = data[: self.input_size]


### PR DESCRIPTION
## Summary
- allow configuring the maximum number of mutation steps
- loop over a random number of steps in `Mutator.mutate`
- expose new `--mutations` CLI option and pass it to `Mutator`
- document multi-step mutation usage and config

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_6849be0535508326b2b07233006ff74a