### PR TITLE
Unify corpus saving logic

### DIFF
--- a/corpus.py
+++ b/corpus.py
@@ -18,25 +18,22 @@ class Corpus:
         self.coverage_hashes = set()
         self.output_bytes = output_bytes
 
-    def save_if_interesting(self, data: bytes, coverage, stdout: bytes = b"", stderr: bytes = b""):
-        """Persist input if it triggers previously unseen coverage."""
-        cov_hash = hashlib.sha1(
-            ",".join(str(c) for c in sorted(coverage)).encode()
-        ).hexdigest()
-        path = os.path.join(self.directory, cov_hash + ".json")
+    def save_input(
+        self,
+        data: bytes,
+        coverage,
+        category: str = "interesting",
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+    ):
+        """Persist *data* and associated *coverage*.
 
-        if cov_hash in self.coverage_hashes or os.path.exists(path):
-            logging.debug("Input with identical coverage already stored")
-            self.coverage.update(coverage)
-            return False
+        If *category* is "interesting", coverage is deduplicated using a hash of
+        the coverage set.  For other categories (e.g. "crash" or "timeout") a
+        timestamped file name is used.  The saved file is JSON formatted and
+        compatible with the existing corpus structure.
+        """
 
-        if not coverage - self.coverage:
-            logging.debug("Input did not yield new coverage")
-            self.coverage.update(coverage)
-            return False
-
-        self.coverage.update(coverage)
-        self.coverage_hashes.add(cov_hash)
         record = {
             "coverage": sorted(coverage),
             "data": base64.b64encode(data).decode("ascii"),
@@ -45,20 +42,35 @@ class Corpus:
             record["stdout"] = base64.b64encode(stdout[: self.output_bytes]).decode("ascii")
         if stderr and self.output_bytes > 0:
             record["stderr"] = base64.b64encode(stderr[: self.output_bytes]).decode("ascii")
+        if category != "interesting":
+            record["type"] = category
+
+        if category == "interesting":
+            cov_hash = hashlib.sha1(
+                ",".join(str(c) for c in record["coverage"]).encode()
+            ).hexdigest()
+            path = os.path.join(self.directory, cov_hash + ".json")
+
+            if cov_hash in self.coverage_hashes or os.path.exists(path):
+                logging.debug("Input with identical coverage already stored")
+                self.coverage.update(coverage)
+                return False, None
+
+            if not coverage - self.coverage:
+                logging.debug("Input did not yield new coverage")
+                self.coverage.update(coverage)
+                return False, None
+
+            self.coverage.update(coverage)
+            self.coverage_hashes.add(cov_hash)
+        else:
+            filename = f"{category}-{int(time.time() * 1000)}.json"
+            path = os.path.join(self.directory, filename)
+
         with open(path, "w") as f:
             json.dump(record, f)
-        logging.info("Saved interesting input to %s", path)
-        return True
-
-    def _save_failure(self, data: bytes, prefix: str) -> str:
-        """Save a crashing or timing-out input and return its path."""
-        os.makedirs(self.directory, exist_ok=True)
-        filename = f"{prefix}-{int(time.time() * 1000)}.bin"
-        path = os.path.join(self.directory, filename)
-        with open(path, "wb") as f:
-            f.write(data)
-        logging.info("Saved %s input to %s", prefix, path)
-        return path
+        logging.info("Saved %s input to %s", category, path)
+        return True, path
 
     def minimize_input(self, path: str, target: str, timeout: float = 1.0,
                         file_input: bool = False, network=None) -> str:
@@ -68,8 +80,14 @@ class Corpus:
         alongside the original file.
         """
         try:
-            with open(path, "rb") as f:
-                data = f.read()
+            mode = "r" if path.endswith(".json") else "rb"
+            record = {}
+            with open(path, mode) as f:
+                if path.endswith(".json"):
+                    record = json.load(f)
+                    data = base64.b64decode(record.get("data", ""))
+                else:
+                    data = f.read()
         except OSError as e:
             logging.debug("Failed to read %s for minimization: %s", path, e)
             return path
@@ -137,7 +155,12 @@ class Corpus:
             return path
 
         min_path = path + ".min"
-        with open(min_path, "wb") as f:
-            f.write(minimal)
+        if path.endswith(".json"):
+            record["data"] = base64.b64encode(minimal).decode("ascii")
+            with open(min_path, "w") as f:
+                json.dump(record, f)
+        else:
+            with open(min_path, "wb") as f:
+                f.write(minimal)
         logging.info("Minimized input saved to %s", min_path)
         return min_path

--- a/main.py
+++ b/main.py
@@ -32,17 +32,23 @@ class Fuzzer:
             )
             if crashed or timed_out:
                 prefix = "crash" if crashed else "timeout"
-                orig = self.corpus._save_failure(data, prefix)
-                self.corpus.minimize_input(
-                    orig, target, timeout, file_input=False, network=network
+                saved, orig = self.corpus.save_input(
+                    data,
+                    coverage_set,
+                    prefix,
+                    stdout_data,
+                    stderr_data,
                 )
-            interesting = self.corpus.save_if_interesting(
-                data, coverage_set, stdout_data, stderr_data
+                if saved:
+                    self.corpus.minimize_input(
+                        orig, target, timeout, file_input=False, network=network
+                    )
+            interesting, path = self.corpus.save_input(
+                data, coverage_set, "interesting", stdout_data, stderr_data
             )
             if interesting:
-                orig = self.corpus._save_failure(data, "interesting")
                 self.corpus.minimize_input(
-                    orig, target, timeout, file_input=False, network=network
+                    path, target, timeout, file_input=False, network=network
                 )
             return interesting, coverage_set
         try:
@@ -111,18 +117,24 @@ class Fuzzer:
 
         if crashed or timed_out:
             prefix = "crash" if crashed else "timeout"
-            orig = self.corpus._save_failure(data, prefix)
-            self.corpus.minimize_input(
-                orig, target, timeout, file_input=file_input
+            saved, orig = self.corpus.save_input(
+                data,
+                coverage_set,
+                prefix,
+                stdout_data,
+                stderr_data,
             )
+            if saved:
+                self.corpus.minimize_input(
+                    orig, target, timeout, file_input=file_input
+                )
 
-        interesting = self.corpus.save_if_interesting(
-            data, coverage_set, stdout_data, stderr_data
+        interesting, path = self.corpus.save_input(
+            data, coverage_set, "interesting", stdout_data, stderr_data
         )
         if interesting:
-            orig = self.corpus._save_failure(data, "interesting")
             self.corpus.minimize_input(
-                orig, target, timeout, file_input=file_input
+                path, target, timeout, file_input=file_input
             )
         return interesting, coverage_set
 


### PR DESCRIPTION
## Summary
- merge crash/timeout saving with interesting case handling
- record all saved inputs in JSON format
- adjust minimization to support JSON files
- update fuzzer to use unified `save_input` method

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_6849c2c5efc8832690b3030673298747