### PR TITLE
Include empty seed for mutator

### DIFF
--- a/mutator.py
+++ b/mutator.py
@@ -37,6 +37,10 @@ class Mutator:
             # Ensure at least one seed exists to mutate
             self.seeds.append(os.urandom(self.input_size))
             self.weights.append(1)
+        # Always include an empty seed for minimal mutations
+        if b"" not in self.seeds:
+            self.seeds.append(b"")
+            self.weights.append(1)
 
     # ---- mutation helpers ----
     def _choose_seed(self) -> bytes:


### PR DESCRIPTION
## Summary
- ensure mutator always has a zero-length seed in addition to the initial random seed

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_6849c6bfc3048326a65049c9295e4473