### PR TITLE
Fix splicing with empty seed

### DIFF
--- a/mutator.py
+++ b/mutator.py
@@ -52,9 +52,11 @@ class Mutator:
         return data
 
     def _splice(self, data: bytearray) -> bytearray:
-        if len(self.seeds) < 2:
+        # Only splice with non-empty seeds to avoid zero-length ranges
+        candidates = [s for s in self.seeds if s]
+        if len(candidates) < 2:
             return self._bitflip(data)
-        other = random.choice(self.seeds)
+        other = random.choice(candidates)
         pivot1 = random.randrange(len(data))
         pivot2 = random.randrange(len(other))
         return data[:pivot1] + other[pivot2:]


### PR DESCRIPTION
## Summary
- avoid choosing zero-length seeds when splicing in `mutator`

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_6849d50e4f04832690752574267eed7d