### PR TITLE
Fix extra newline output in corpus_analyzer

### DIFF
--- a/corpus_analyzer.py
+++ b/corpus_analyzer.py
@@ -46,7 +46,7 @@ def main() -> None:
 
         for key in ("stdout", "stderr"):
             if key in record:
-                print(f"{basename} {key.upper()}:")
-                print(_decode_field(record[key]).rstrip())
+                decoded = _decode_field(record[key]).rstrip()
+                print(f"{basename} {key.upper()}: {decoded}")
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- trim trailing newline from stdout and stderr values in `corpus_analyzer`

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_6849d632021483269b56d8ba4fa0c07c