### PR TITLE
Add example fuzz target with build and run scripts

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Example Fuzz Targets
+
+This directory contains small programs used as fuzzing examples for the
+project.  Each subdirectory holds an individual target along with its build
+files and an optional script to run the fuzzer.
+
+- `target1` – simple program that reads from `stdin` without bounds checking.

--- a/examples/target1/Makefile
+++ b/examples/target1/Makefile
@@ -1,0 +1,14 @@
+CC ?= gcc
+CFLAGS ?= -O0 -g -fno-stack-protector -z execstack
+LDFLAGS ?=
+TARGET = target1
+
+all: $(TARGET)
+
+$(TARGET): target1.c
+$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+rm -f $(TARGET)
+
+.PHONY: all clean

--- a/examples/target1/fuzz.sh
+++ b/examples/target1/fuzz.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Build the target and run the Python fuzzer against it
+set -e
+
+# Build the C program
+make -C "$(dirname "$0")"
+
+# Create a corpus directory relative to this script
+CORPUS_DIR="$(dirname "$0")/corpus"
+mkdir -p "$CORPUS_DIR"
+
+# Run the fuzzer with a small number of iterations by default
+python3 ../../main.py --target "$(dirname "$0")/target1" --iterations 10 \
+    --input-size 64 --corpus-dir "$CORPUS_DIR" "$@"

--- a/examples/target1/target1.c
+++ b/examples/target1/target1.c
@@ -1,0 +1,9 @@
+// target1.c – single-call stack smash.
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+    char buf[8];
+    fread(buf, 1, 64, stdin);   // no bounds check
+    puts("done");
+}


### PR DESCRIPTION
## Summary
- add `examples/target1` with simple stack-smash C program
- provide Makefile to build the binary
- add helper script to fuzz the program
- document example targets

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_684ad69a7c308326b3c65cd372249909