### PR TITLE
Ensure attachment before target runs

### DIFF
--- a/coverage_linux.py
+++ b/coverage_linux.py
@@ -91,7 +91,7 @@ def _get_image_base(pid, exe):
     return 0
 
 
-def collect_coverage(pid, timeout=1.0, exe=None):
+def collect_coverage(pid, timeout=1.0, exe=None, already_traced=False):
     logging.debug("Collecting coverage for pid %d", pid)
     coverage = set()
     prev_addr = None
@@ -106,9 +106,10 @@ def collect_coverage(pid, timeout=1.0, exe=None):
     if exe is not None:
         exe = os.path.realpath(exe)
 
-    _ptrace(PTRACE_ATTACH, pid)
-    os.waitpid(pid, 0)
-    logging.debug("Attached to pid %d", pid)
+    if not already_traced:
+        _ptrace(PTRACE_ATTACH, pid)
+        os.waitpid(pid, 0)
+        logging.debug("Attached to pid %d", pid)
 
     base = _get_image_base(pid, exe) if exe else 0
     if exe and base == 0:

--- a/coverage_macos.py
+++ b/coverage_macos.py
@@ -86,7 +86,7 @@ def _get_image_base(pid, exe):
     return 0
 
 
-def collect_coverage(pid, timeout=1.0, exe=None):
+def collect_coverage(pid, timeout=1.0, exe=None, already_traced=False):
     logging.debug("Collecting coverage for pid %d (macOS ptrace)", pid)
     coverage = set()
     prev_addr = None
@@ -96,9 +96,10 @@ def collect_coverage(pid, timeout=1.0, exe=None):
 
     exe = os.path.realpath(exe)
 
-    _ptrace(PTRACE_ATTACH, pid)
-    os.waitpid(pid, 0)
-    logging.debug("Attached to pid %d", pid)
+    if not already_traced:
+        _ptrace(PTRACE_ATTACH, pid)
+        os.waitpid(pid, 0)
+        logging.debug("Attached to pid %d", pid)
 
     base = _get_image_base(pid, exe)
     if base == 0:


### PR DESCRIPTION
## Summary
- start targets with `ptrace(PTRACE_TRACEME)` so they pause before executing
- wait for the child to stop and collect coverage while already traced
- allow coverage modules to skip `PTRACE_ATTACH`

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_684ae3e5b9f08326ad3e502d7acdf765