### PR TITLE
Add iteration logging for minimization

### DIFF
--- a/corpus.py
+++ b/corpus.py
@@ -143,12 +143,15 @@ class Corpus:
 
         minimal = data
         step = len(minimal) // 2
+        iterations = 0
         while step > 0 and len(minimal) > 1:
+            iterations += 1
             reduced = minimal[: len(minimal) - step]
             if reproduces_crash(reduced):
                 minimal = reduced
             else:
                 step //= 2
+        logging.info("Minimization loop executed %d iterations", iterations)
 
         if minimal == data:
             logging.info("Input already minimal")


### PR DESCRIPTION
## Summary
- log how many iterations the minimization loop ran

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_684b0184a8f08326a3fb3a3254c58696