### PR TITLE
Refine README: Further simplify target2 description

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,26 @@
 # Example Fuzz Targets
 
-This directory contains small programs used as fuzzing examples for the
-project.  Each subdirectory holds an individual target along with its build
-files and an optional script to run the fuzzer.
+This directory contains small programs used as fuzzing examples for the project.
+Each subdirectory holds an individual target along with its build files and a `fuzz.sh` script to run the fuzzer.
 
-- `target1` – simple program that reads from `stdin` without bounds checking.
+## How to Fuzz Examples
+
+For each example target located in a subdirectory (e.g., `examples/<target_name>`):
+1. Navigate to the target's directory: `cd examples/<target_name>`
+2. Execute the fuzzing script: `./fuzz.sh`
+
+This script will compile the target program and then run the main fuzzer against it. Specific parameters like input size are configured within each `fuzz.sh` script.
+
+---
+
+## Target 1: Basic Stack Smash (`examples/target1`)
+
+**Challenge:** Discovering a direct buffer overflow.
+
+`target1.c` is a very simple program that reads data from `stdin` directly into a small fixed-size buffer on the stack without any bounds checking. The fuzzer's challenge is to provide an input larger than this buffer to trigger a crash via stack smashing.
+
+## Target 2: Conditional Stack Smash with Single-Byte Prefix (`examples/target2`)
+
+**Challenge:** Satisfying a simple prefix condition to reach a buffer overflow.
+
+`target2.c` introduces a condition before a stack buffer overflow: the input must start with the magic byte 'X'. If this magic byte is present, the program then attempts to copy subsequent input bytes into a small stack buffer, leading to an overflow if the input is sufficiently long. If the 'X' prefix is missing, the vulnerable code path is not reached.

--- a/examples/target2/Makefile
+++ b/examples/target2/Makefile
@@ -1,0 +1,17 @@
+# Makefile for target2
+CC ?= gcc
+CFLAGS ?= -O0 -g -fno-stack-protector -z execstack
+LDFLAGS ?=
+
+TARGET=target2
+SRC=$(TARGET).c
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(CC) $(CFLAGS) -o $(TARGET) $(SRC) $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: all clean

--- a/examples/target2/fuzz.sh
+++ b/examples/target2/fuzz.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Build the target and run the Python fuzzer against it
+set -e
+
+# Build the C program
+make -C "$(dirname "$0")"
+
+# Create a corpus directory relative to this script
+CORPUS_DIR="$(dirname "$0")/corpus"
+mkdir -p "$CORPUS_DIR"
+
+# Run the fuzzer with a small number of iterations by default
+# Input size is 65 to accommodate "X" prefix + 64 bytes for the overflow
+python3 ../../main.py --target "$(dirname "$0")/target2" --iterations 10 \
+    --input-size 65 --corpus-dir "$CORPUS_DIR" --output-bytes 1024 "$@"

--- a/examples/target2/target2.c
+++ b/examples/target2/target2.c
@@ -1,0 +1,35 @@
+// target2.c - conditional stack smash with single-byte prefix.
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h> // For exit()
+
+int main(void) {
+    char buf[8];
+    // Buffer to hold the magic byte + 64 bytes for the overflow attempt
+    char input_buffer[65];
+
+    // Read up to 65 bytes. We expect at least 1 for the magic byte.
+    size_t bytes_read = fread(input_buffer, 1, sizeof(input_buffer) -1, stdin);
+    input_buffer[bytes_read] = '\0'; // Null-terminate the actual input
+
+    if (bytes_read < 1) {
+        // Not enough input for magic byte
+        puts("Too short");
+        return 1;
+    }
+
+    // Check for the magic byte 'X'
+    if (input_buffer[0] == 'X') {
+        // If magic byte is present, then attempt to copy up to 64 bytes
+        // from the rest of the input into buf, causing overflow.
+        // Ensure we don't read past what was actually read into input_buffer if it's less than 1+64.
+        size_t len_to_copy = bytes_read > 1 ? bytes_read - 1 : 0;
+        if (len_to_copy > 0) {
+             memcpy(buf, input_buffer + 1, len_to_copy > 64 ? 64 : len_to_copy);
+        }
+        puts("Magic received!");
+    } else {
+        puts("No magic.");
+    }
+    return 0;
+}


### PR DESCRIPTION
Based on your feedback, this commit makes the description of `target2` in `examples/README.md` more concise by:

- Removing the sentence detailing its Makefile configuration.
- Removing the final sentence that compared its difficulty to `target1`.

The description now focuses solely on the core mechanism of the `target2` challenge.