### PR TITLE
Add CFG visualization tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,3 +197,20 @@ directory.
 python3 -m fz.corpus.analyzer --corpus-dir ./corpus
 ```
 
+## Control Flow Graph Visualization
+
+The `fz-cfg` script generates a Graphviz representation of a binary's possible
+control flow graph using static analysis. When run without an output file the
+DOT graph is printed to stdout:
+
+```bash
+fz-cfg /usr/bin/file
+```
+
+Provide `--output` to write the DOT data to a file that can be rendered with
+Graphviz:
+
+```bash
+fz-cfg /usr/bin/file --output file.dot
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.8"
 [project.scripts]
 fz = "fz.__main__:main"
 fz-corpus-analyzer = "fz.corpus.analyzer:main"
+fz-cfg = "fz.coverage.visualize:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/fz/coverage/__init__.py
+++ b/src/fz/coverage/__init__.py
@@ -8,5 +8,6 @@ else:
 
 from .cfg import ControlFlowGraph  # noqa: F401
 from .utils import get_possible_edges  # noqa: F401
+from .visualize import main as visualize_cfg  # noqa: F401
 
-__all__ = ["collect_coverage", "ControlFlowGraph", "get_possible_edges"]
+__all__ = ["collect_coverage", "ControlFlowGraph", "get_possible_edges", "visualize_cfg"]

--- a/src/fz/coverage/cfg.py
+++ b/src/fz/coverage/cfg.py
@@ -34,3 +34,21 @@ class ControlFlowGraph:
 
     def num_nodes(self):
         return len(self.adj)
+
+    def to_dot(self) -> str:
+        """Return the graph in Graphviz dot format."""
+        lines = ["digraph cfg {"]
+        for src, dsts in self.adj.items():
+            for dst in dsts:
+                edge = (src, dst)
+                attrs = []
+                if edge not in self.edge_counts:
+                    if edge in self.possible_edges:
+                        attrs.append("style=dashed")
+                if edge in self.edge_counts:
+                    count = self.edge_counts[edge]
+                    attrs.append(f"label=\"{count}\"")
+                attr_str = "" if not attrs else " [" + ",".join(attrs) + "]"
+                lines.append(f"    \"{src:#x}\" -> \"{dst:#x}\"{attr_str};")
+        lines.append("}")
+        return "\n".join(lines)

--- a/src/fz/coverage/visualize.py
+++ b/src/fz/coverage/visualize.py
@@ -1,0 +1,25 @@
+import argparse
+from .utils import get_possible_edges
+from .cfg import ControlFlowGraph
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Visualize the control flow graph of a binary")
+    parser.add_argument("binary", help="Path to the binary to analyze")
+    parser.add_argument("--output", "-o", help="Write DOT graph to file instead of stdout")
+    args = parser.parse_args()
+
+    edges = get_possible_edges(args.binary)
+    cfg = ControlFlowGraph()
+    cfg.add_possible_edges(edges)
+    dot = cfg.to_dot()
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(dot)
+    else:
+        print(dot)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `to_dot` method for CFG dot export
- implement `fz-cfg` entry point for generating graphviz output
- document CFG visualization in README

## Testing
- `python3 -m py_compile *.py` *(fails: file not found)*
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1` *(fails: file not found)*
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2` *(fails: file not found)*
- `python3 -m fz.coverage.visualize /bin/true > /tmp/cfg.dot`

------
https://chatgpt.com/codex/tasks/task_e_684c4e85fed08326875651d469916321