### PR TITLE
Add SVG output option to fz-cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,10 @@ Graphviz:
 fz-cfg /usr/bin/file --output file.dot
 ```
 
+To generate an SVG directly without keeping the intermediate DOT data, use
+`--svg`:
+
+```bash
+fz-cfg /usr/bin/file --svg file.svg
+```
+

--- a/src/fz/coverage/visualize.py
+++ b/src/fz/coverage/visualize.py
@@ -1,4 +1,5 @@
 import argparse
+import subprocess
 from .utils import get_possible_edges
 from .cfg import ControlFlowGraph
 
@@ -6,7 +7,9 @@ from .cfg import ControlFlowGraph
 def main() -> None:
     parser = argparse.ArgumentParser(description="Visualize the control flow graph of a binary")
     parser.add_argument("binary", help="Path to the binary to analyze")
-    parser.add_argument("--output", "-o", help="Write DOT graph to file instead of stdout")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--output", "-o", help="Write DOT graph to file instead of stdout")
+    group.add_argument("--svg", help="Render graph directly to an SVG file")
     args = parser.parse_args()
 
     edges = get_possible_edges(args.binary)
@@ -14,7 +17,14 @@ def main() -> None:
     cfg.add_possible_edges(edges)
     dot = cfg.to_dot()
 
-    if args.output:
+    if args.svg:
+        result = subprocess.run([
+            "dot",
+            "-Tsvg",
+        ], input=dot.encode(), stdout=subprocess.PIPE, check=True)
+        with open(args.svg, "wb") as f:
+            f.write(result.stdout)
+    elif args.output:
         with open(args.output, "w") as f:
             f.write(dot)
     else:


### PR DESCRIPTION
## Summary
- allow `fz-cfg` to directly render SVG using `--svg`
- document the new `--svg` option

## Testing
- `python3 -m py_compile *.py` *(fails: No such file or directory)*
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1` *(fails: main.py not found)*
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2` *(fails: main.py not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7d70335083268ee2c720cc2d626c