### PR TITLE
Improve minimization routine

### DIFF
--- a/src/fz/corpus/corpus.py
+++ b/src/fz/corpus/corpus.py
@@ -111,15 +111,27 @@ class Corpus:
             return crashed or timed_out
 
         minimal = data
-        step = len(minimal) // 2
+        step = max(1, len(minimal) // 2)
         iterations = 0
+
         while step > 0 and len(minimal) > 1:
             iterations += 1
-            reduced = minimal[: len(minimal) - step]
-            if reproduces_crash(reduced):
-                minimal = reduced
-            else:
+            i = 0
+            changed = False
+
+            while i + step <= len(minimal) and len(minimal) > 1:
+                candidate = minimal[:i] + minimal[i + step :]
+                if len(candidate) == 0:
+                    break
+                if reproduces_crash(candidate):
+                    minimal = candidate
+                    changed = True
+                else:
+                    i += step
+
+            if not changed:
                 step //= 2
+
         logging.info("Minimization loop executed %d iterations", iterations)
 
         if minimal == data:


### PR DESCRIPTION
## Summary
- improve the minimization loop to drop byte ranges from any offset

## Testing
- `python3 -m py_compile *.py` *(fails: No such file or directory)*
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1` *(fails: can't open file 'main.py')*
- `python3 main.py --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2` *(fails: can't open file 'main.py')*
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_684c80e272788326975d622637ebc7fe