### PR TITLE
Fix debug log spam when restoring breakpoints

### DIFF
--- a/src/fz/coverage/linux.py
+++ b/src/fz/coverage/linux.py
@@ -5,6 +5,7 @@ import os
 import platform
 import signal
 import time
+import errno
 
 from .utils import get_basic_blocks
 
@@ -219,6 +220,11 @@ def collect_coverage(pid, timeout=1.0, exe=None, already_traced=False):
                 else:
                     _ptrace_poke(pid, addr, info)
             except OSError as e:
+                if e.errno == errno.ESRCH:
+                    logging.debug(
+                        "Process %d disappeared while restoring breakpoints", pid
+                    )
+                    break
                 logging.debug("Failed to restore breakpoint at %#x: %s", addr, e)
         _ptrace(PTRACE_DETACH, pid)
         logging.debug("Detached from pid %d", pid)

--- a/src/fz/coverage/macos.py
+++ b/src/fz/coverage/macos.py
@@ -7,6 +7,7 @@ import re
 import signal
 import subprocess
 import time
+import errno
 
 from .utils import get_basic_blocks
 
@@ -209,6 +210,11 @@ def collect_coverage(pid, timeout=1.0, exe=None, already_traced=False):
                 else:
                     _ptrace_poke(pid, addr, info)
             except OSError as e:
+                if e.errno == errno.ESRCH:
+                    logging.debug(
+                        "Process %d disappeared while restoring breakpoints", pid
+                    )
+                    break
                 logging.debug("Failed to restore breakpoint at %#x: %s", addr, e)
         _ptrace(PTRACE_DETACH, pid)
         logging.debug("Detached from pid %d", pid)


### PR DESCRIPTION
## Summary
- avoid repeated ESRCH errors when restoring breakpoints on both Linux and macOS

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`


------
https://chatgpt.com/codex/tasks/task_e_684c841cc3888326b1988832c70b015f