### PR TITLE
Add aggregated stats across processes

### DIFF
--- a/src/fz/corpus/corpus.py
+++ b/src/fz/corpus/corpus.py
@@ -148,3 +148,23 @@ class Corpus:
                 f.write(minimal)
         logging.info("Minimized input saved to %s", min_path)
         return min_path
+
+
+def corpus_stats(directory: str) -> tuple[int, int]:
+    """Return the number of corpus entries and unique edges in *directory*."""
+    entries = 0
+    edges = set()
+    if not os.path.isdir(directory):
+        return entries, 0
+    for name in os.listdir(directory):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            with open(path) as f:
+                record = json.load(f)
+            edges.update(tuple(e) for e in record.get("coverage", []))
+            entries += 1
+        except Exception:
+            continue
+    return entries, len(edges)

--- a/src/fz/worker.py
+++ b/src/fz/worker.py
@@ -1,0 +1,9 @@
+import logging
+from .__main__ import Fuzzer
+
+def worker(args, result_queue=None):
+    if not logging.getLogger().hasHandlers():
+        level = logging.DEBUG if getattr(args, "debug", False) else logging.INFO
+        logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(message)s")
+    fuzzer = Fuzzer(args.corpus_dir, args.output_bytes)
+    fuzzer._fuzz_loop(args, result_queue)


### PR DESCRIPTION
## Summary
- collect corpus statistics from disk
- aggregate worker results for parallel fuzzing
- provide worker entry point that multiprocess can import

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_684c86adf7748326995c05a8393f1926