### PR TITLE
Add live progress display with shared counters

### DIFF
--- a/src/fz/__main__.py
+++ b/src/fz/__main__.py
@@ -83,7 +83,7 @@ class Fuzzer:
         self.cfg.add_edges(coverage_set)
         return interesting, coverage_set
 
-    def _fuzz_loop(self, args):
+    def _fuzz_loop(self, args, iter_counter=None, saved_counter=None):
         mode = "file" if args.file_input else "stdin"
         harness = None
         if args.tcp:
@@ -106,6 +106,7 @@ class Fuzzer:
 
         start_time = time.time()
         i = 0
+        saved = 0
         from fz.corpus.mutator import Mutator
         mutator = Mutator(args.corpus_dir, args.input_size, args.mutations, cfg=self.cfg)
         try:
@@ -116,6 +117,14 @@ class Fuzzer:
                     args.target, data, args.timeout, args.file_input, harness
                 )
                 mutator.record_result(data, coverage_set, interesting)
+                if interesting:
+                    saved += 1
+                    if saved_counter is not None:
+                        with saved_counter.get_lock():
+                            saved_counter.value += 1
+                if iter_counter is not None:
+                    with iter_counter.get_lock():
+                        iter_counter.value += 1
                 i += 1
                 if not args.run_forever and i >= args.iterations:
                     break
@@ -132,33 +141,106 @@ class Fuzzer:
             )
         else:
             logging.info("Executed %d iterations", i)
+        stats = {
+            "iterations": i,
+            "saved": saved,
+            "duration": duration,
+            "edges": self.cfg.num_edges(),
+        }
+        return stats
 
     def run(self, args):
         if args.parallel > 1:
             import multiprocessing
+            from fz.corpus.corpus import corpus_stats
 
-            ctx = multiprocessing.get_context("spawn")
+            ctx = multiprocessing.get_context()
+            iter_counter = ctx.Value('i', 0)
+            saved_counter = ctx.Value('i', 0)
 
             processes = []
+            start_time = time.time()
+
             for _ in range(args.parallel):
-                p = ctx.Process(target=_worker, args=(args,))
+                p = ctx.Process(target=_worker, args=(args, iter_counter, saved_counter))
                 p.start()
                 processes.append(p)
-            for p in processes:
-                p.join()
+
+            try:
+                table = None
+                try:
+                    from rich.live import Live
+                    from rich.table import Table
+                    table = Table()
+                    table.add_column("Iterations", justify="right")
+                    table.add_column("Saved", justify="right")
+                    table.add_column("Rate", justify="right")
+                    table.add_column("Corpus", justify="right")
+                    table.add_column("Edges", justify="right")
+                except Exception:
+                    Live = None
+
+                def snapshot():
+                    elapsed = time.time() - start_time
+                    iters = iter_counter.value
+                    saves = saved_counter.value
+                    rate = iters / elapsed if elapsed > 0 else 0.0
+                    samples, edges = corpus_stats(args.corpus_dir)
+                    if table is None:
+                        return (
+                            f"iters={iters} saved={saves} rate={rate:.2f}/sec "
+                            f"corpus={samples} edges={edges}"
+                        )
+                    table.rows = []
+                    table.add_row(
+                        str(iters),
+                        str(saves),
+                        f"{rate:.2f}/sec",
+                        str(samples),
+                        str(edges),
+                    )
+                    return table
+
+                if Live:
+                    with Live(snapshot(), refresh_per_second=1) as live:
+                        while any(p.is_alive() for p in processes):
+                            live.update(snapshot())
+                            time.sleep(1)
+                else:
+                    while any(p.is_alive() for p in processes):
+                        print(snapshot(), end="\r", flush=True)
+                        time.sleep(1)
+            finally:
+                for p in processes:
+                    p.join()
+
+            duration = time.time() - start_time
+            total_iters = iter_counter.value
+            total_saved = saved_counter.value
+            if duration > 0:
+                rate = total_iters / duration
+                logging.info(
+                    "Executed %d iterations in %.2f seconds (%.2f/sec)",
+                    total_iters,
+                    duration,
+                    rate,
+                )
+            else:
+                logging.info("Executed %d iterations", total_iters)
+            samples, edges = corpus_stats(args.corpus_dir)
+            logging.info("Corpus entries: %d (+%d new)", samples, total_saved)
+            logging.info("Unique coverage edges: %d", edges)
             return
 
         self._fuzz_loop(args)
 
 
-def _worker(args):
+def _worker(args, iter_counter=None, saved_counter=None):
     if not logging.getLogger().hasHandlers():
-        level = logging.DEBUG if args.debug else logging.INFO
+        level = logging.DEBUG if getattr(args, "debug", False) else logging.INFO
         logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(message)s")
     fuzzer = Fuzzer(args.corpus_dir, args.output_bytes)
-    fuzzer._fuzz_loop(args)
-
-
+    fuzzer._fuzz_loop(args, iter_counter, saved_counter)
 def parse_args():
     # First parse only the --config argument so we can load defaults from file
     config_parser = argparse.ArgumentParser(add_help=False)

--- a/src/fz/corpus/corpus.py
+++ b/src/fz/corpus/corpus.py
@@ -148,3 +148,23 @@ class Corpus:
                 f.write(minimal)
         logging.info("Minimized input saved to %s", min_path)
         return min_path
+
+
+def corpus_stats(directory: str) -> tuple[int, int]:
+    """Return the number of corpus entries and unique edges in *directory*."""
+    entries = 0
+    edges = set()
+    if not os.path.isdir(directory):
+        return entries, 0
+    for name in os.listdir(directory):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            with open(path) as f:
+                record = json.load(f)
+            edges.update(tuple(e) for e in record.get("coverage", []))
+            entries += 1
+        except Exception:
+            continue
+    return entries, len(edges)


### PR DESCRIPTION
## Summary
- track iterations and saved samples with shared counters
- show a live status table with `rich` when available
- remove unnecessary worker module

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_684c86adf7748326995c05a8393f1926