### PR TITLE
Refactor coverage collector

### DIFF
--- a/src/fz/coverage/__init__.py
+++ b/src/fz/coverage/__init__.py
@@ -1,13 +1,23 @@
-"""Platform-dispatching coverage collection."""
+"""Coverage collector factory and utilities."""
 import platform
 
-if platform.system() == "Darwin":
-    from .macos import collect_coverage  # noqa: F401
-else:
-    from .linux import collect_coverage  # noqa: F401
+from .collector import CoverageCollector, LinuxCollector, MacOSCollector
+from .cfg import ControlFlowGraph
+from .utils import get_possible_edges
+from .visualize import main as visualize_cfg
 
-from .cfg import ControlFlowGraph  # noqa: F401
-from .utils import get_possible_edges  # noqa: F401
-from .visualize import main as visualize_cfg  # noqa: F401
 
-__all__ = ["collect_coverage", "ControlFlowGraph", "get_possible_edges", "visualize_cfg"]
+def get_collector() -> CoverageCollector:
+    """Return a :class:`CoverageCollector` for the current platform."""
+    if platform.system() == "Darwin":
+        return MacOSCollector()
+    return LinuxCollector()
+
+__all__ = [
+    "CoverageCollector",
+    "get_collector",
+    "ControlFlowGraph",
+    "get_possible_edges",
+    "visualize_cfg",
+]
+

--- a/src/fz/coverage/collector.py
+++ b/src/fz/coverage/collector.py
@@ -1,0 +1,238 @@
+import ctypes
+import logging
+import os
+import platform
+import signal
+import time
+import errno
+import subprocess
+import re
+from abc import ABC, abstractmethod
+from typing import Optional, Set
+
+from .utils import get_basic_blocks
+from .common import _ptrace, _ptrace_peek, _ptrace_poke
+
+ARCH = platform.machine().lower()
+if ARCH in ("aarch64", "arm64"):
+    from ..arch import arm64 as arch
+else:
+    from ..arch import x86 as arch
+
+PTRACE_ATTACH = 16
+PTRACE_DETACH = 17
+PTRACE_CONT = 7
+PTRACE_SINGLESTEP = 9
+PTRACE_GETREGS = 12
+PTRACE_SETREGS = 13
+
+BREAKPOINT = arch.BREAKPOINT
+user_regs_struct = arch.user_regs_struct
+get_pc = arch.get_pc
+set_pc = arch.set_pc
+
+
+class CoverageCollector(ABC):
+    """Base class implementing common breakpoint coverage logic."""
+
+    @abstractmethod
+    def _resolve_exe(self, pid: int, exe: Optional[str]) -> Optional[str]:
+        """Return the executable path for *pid* or raise if unavailable."""
+
+    @abstractmethod
+    def _get_image_base(self, pid: int, exe: str) -> int:
+        """Return the loaded base address for *exe* in *pid*."""
+
+    def collect_coverage(
+        self, pid: int, timeout: float = 1.0, exe: Optional[str] = None, already_traced: bool = False
+    ) -> Set[tuple]:
+        """Collect basic block transition coverage from a traced process."""
+        logging.debug("Collecting coverage for pid %d", pid)
+        coverage = set()
+        prev_addr = None
+        word_cache = {}
+
+        exe = self._resolve_exe(pid, exe)
+
+        if not already_traced:
+            _ptrace(PTRACE_ATTACH, pid)
+            os.waitpid(pid, 0)
+            logging.debug("Attached to pid %d", pid)
+
+        base = self._get_image_base(pid, exe) if exe else 0
+        if exe and base == 0:
+            logging.debug("Base address not found for %s", exe)
+        logging.debug("%s loaded at %#x", exe, base)
+
+        logging.debug("Inserting breakpoints for block coverage on %s", exe)
+        blocks = get_basic_blocks(exe) if exe else []
+        blocks = [base + b for b in blocks]
+        breakpoints = {}
+        for b in blocks:
+            try:
+                if ARCH in ("aarch64", "arm64"):
+                    word_addr = b & ~7
+                    offset = b & 7
+                    if word_addr not in word_cache:
+                        orig_word = _ptrace_peek(pid, word_addr)
+                        patched_word = orig_word
+                        patches = set()
+                    else:
+                        orig_word, patched_word, patches = word_cache[word_addr]
+                    if offset == 0:
+                        patched_word = (patched_word & ~0xFFFFFFFF) | BREAKPOINT
+                    else:
+                        patched_word = (patched_word & 0xFFFFFFFF) | (BREAKPOINT << 32)
+                    _ptrace_poke(pid, word_addr, patched_word)
+                    patches.add(offset)
+                    word_cache[word_addr] = (orig_word, patched_word, patches)
+                    breakpoints[b] = (word_addr, offset)
+                else:
+                    orig = _ptrace_peek(pid, b)
+                    breakpoints[b] = orig
+                    _ptrace_poke(pid, b, (orig & ~0xFF) | BREAKPOINT)
+                logging.debug("Breakpoint inserted at %#x", b)
+            except OSError as e:
+                logging.debug("Failed to insert breakpoint at %#x: %s", b, e)
+                continue
+
+        _ptrace(PTRACE_CONT, pid)
+        regs = user_regs_struct()
+        end_time = time.time() + timeout * 2
+        while True:
+            try:
+                wpid, status = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                logging.debug("Child process %d disappeared", pid)
+                break
+            if wpid == 0:
+                if time.time() > end_time:
+                    logging.debug("Coverage wait timed out")
+                    break
+                time.sleep(0)
+                continue
+            if os.WIFEXITED(status) or os.WIFSIGNALED(status):
+                break
+            if os.WIFSTOPPED(status) and os.WSTOPSIG(status) == signal.SIGTRAP:
+                _ptrace(PTRACE_GETREGS, pid, 0, ctypes.addressof(regs))
+                pc = get_pc(regs)
+                addr = pc - (4 if ARCH in ("aarch64", "arm64") else 1)
+                if addr in breakpoints:
+                    curr = addr - base
+                    if prev_addr is not None:
+                        coverage.add((prev_addr, curr))
+                    prev_addr = curr
+                    logging.debug("Hit breakpoint at %#x", addr)
+                    info = breakpoints.pop(addr)
+                    if ARCH in ("aarch64", "arm64"):
+                        word_addr, offset = info
+                        orig_word, patched_word, patches = word_cache[word_addr]
+                        if offset == 0:
+                            patched_word = (patched_word & ~0xFFFFFFFF) | (orig_word & 0xFFFFFFFF)
+                        else:
+                            patched_word = (patched_word & 0xFFFFFFFF) | (orig_word & 0xFFFFFFFF00000000)
+                        patches.discard(offset)
+                        if not patches:
+                            _ptrace_poke(pid, word_addr, orig_word)
+                            del word_cache[word_addr]
+                        else:
+                            _ptrace_poke(pid, word_addr, patched_word)
+                            word_cache[word_addr] = (orig_word, patched_word, patches)
+                        set_pc(regs, addr)
+                    else:
+                        _ptrace_poke(pid, addr, info)
+                        set_pc(regs, addr)
+                    _ptrace(PTRACE_SETREGS, pid, 0, ctypes.addressof(regs))
+                    _ptrace(PTRACE_SINGLESTEP, pid)
+                    os.waitpid(pid, 0)
+            _ptrace(PTRACE_CONT, pid)
+
+        try:
+            for addr, info in breakpoints.items():
+                try:
+                    if ARCH in ("aarch64", "arm64"):
+                        word_addr, offset = info
+                        orig_word, patched_word, patches = word_cache.get(word_addr, (0, 0, set()))
+                        if offset == 0:
+                            patched_word = (patched_word & ~0xFFFFFFFF) | (orig_word & 0xFFFFFFFF)
+                        else:
+                            patched_word = (patched_word & 0xFFFFFFFF) | (orig_word & 0xFFFFFFFF00000000)
+                        patches.discard(offset)
+                        if not patches:
+                            _ptrace_poke(pid, word_addr, orig_word)
+                            word_cache.pop(word_addr, None)
+                        else:
+                            _ptrace_poke(pid, word_addr, patched_word)
+                            word_cache[word_addr] = (orig_word, patched_word, patches)
+                    else:
+                        _ptrace_poke(pid, addr, info)
+                except OSError as e:
+                    if e.errno == errno.ESRCH:
+                        logging.debug("Process %d disappeared while restoring breakpoints", pid)
+                        break
+                    logging.debug("Failed to restore breakpoint at %#x: %s", addr, e)
+            _ptrace(PTRACE_DETACH, pid)
+            logging.debug("Detached from pid %d", pid)
+        except OSError as e:
+            logging.debug("Failed to detach from pid %d: %s", pid, e)
+
+        logging.debug("Collected %d basic block transitions", len(coverage))
+        return coverage
+
+
+class LinuxCollector(CoverageCollector):
+    """Coverage collector implementation for Linux."""
+
+    def _resolve_exe(self, pid: int, exe: Optional[str]) -> Optional[str]:
+        if exe is None:
+            try:
+                exe = os.readlink(f"/proc/{pid}/exe")
+            except OSError as e:
+                logging.debug("Failed to read executable path for pid %d: %s", pid, e)
+                exe = None
+        if exe is not None:
+            exe = os.path.realpath(exe)
+        return exe
+
+    def _get_image_base(self, pid: int, exe: str) -> int:
+        exe = os.path.realpath(exe)
+        try:
+            with open(f"/proc/{pid}/maps") as f:
+                for line in f:
+                    parts = line.rstrip().split(None, 5)
+                    if len(parts) < 6:
+                        continue
+                    addr_range, perms, offset, _dev, _inode, path = parts
+                    if path != exe or "x" not in perms:
+                        continue
+                    start = int(addr_range.split("-", 1)[0], 16)
+                    off = int(offset, 16)
+                    return start - off
+        except FileNotFoundError:
+            logging.debug("/proc/%d/maps not found", pid)
+        logging.debug("Base address for %s not found in /proc/%d/maps", exe, pid)
+        return 0
+
+
+class MacOSCollector(CoverageCollector):
+    """Coverage collector implementation for macOS."""
+
+    def _resolve_exe(self, pid: int, exe: Optional[str]) -> Optional[str]:
+        if exe is None:
+            raise RuntimeError("Executable path required for macOS")
+        return os.path.realpath(exe)
+
+    def _get_image_base(self, pid: int, exe: str) -> int:
+        exe = os.path.realpath(exe)
+        try:
+            output = subprocess.check_output(["vmmap", str(pid)], text=True)
+            for line in output.splitlines():
+                if "__TEXT" in line and exe in line:
+                    m = re.search(r"([0-9a-fA-F]+)-", line)
+                    if m:
+                        return int(m.group(1), 16)
+        except Exception as e:  # pragma: no cover - best effort for macOS
+            logging.debug("Failed to determine base on macOS: %s", e)
+        logging.debug("Base address for %s not found on macOS", exe)
+        return 0
+

--- a/src/fz/harness/network.py
+++ b/src/fz/harness/network.py
@@ -60,7 +60,8 @@ class NetworkHarness:
             logging.debug("Sending %d bytes", len(data))
             sock.sendall(data)
             sock.close()
-            coverage_set = coverage.collect_coverage(
+            collector = coverage.get_collector()
+            coverage_set = collector.collect_coverage(
                 proc.pid, timeout, already_traced=True
             )
             logging.debug("Collected %d coverage entries", len(coverage_set))

--- a/src/fz/runner/target.py
+++ b/src/fz/runner/target.py
@@ -62,8 +62,9 @@ def run_target(
                     logging.debug("Broken pipe when closing stdin")
 
         logging.debug("Collecting coverage from pid %d", proc.pid)
+        collector = coverage.get_collector()
         try:
-            coverage_set = coverage.collect_coverage(
+            coverage_set = collector.collect_coverage(
                 proc.pid, timeout, target, already_traced=True
             )
         except FileNotFoundError:


### PR DESCRIPTION
## Summary
- centralize breakpoint coverage logic in new `CoverageCollector`
- add `LinuxCollector` and `MacOSCollector` subclasses
- expose `get_collector` factory
- update runner and network harness to use the new collector API

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`


------
https://chatgpt.com/codex/tasks/task_e_684d7106e3fc83269841e37ee361363a