### PR TITLE
Enhance coverage docs and typing

### DIFF
--- a/src/fz/coverage/__init__.py
+++ b/src/fz/coverage/__init__.py
@@ -1,4 +1,10 @@
-"""Coverage collector factory and utilities."""
+"""Coverage collector factory and utilities.
+
+This module exposes helper functions and classes used throughout the
+``fz.coverage`` package.  The :func:`get_collector` convenience function
+returns an appropriate :class:`CoverageCollector` implementation for the
+current platform.
+"""
 import platform
 
 from .collector import CoverageCollector, LinuxCollector, MacOSCollector
@@ -8,7 +14,7 @@ from .visualize import main as visualize_cfg
 
 
 def get_collector() -> CoverageCollector:
-    """Return a :class:`CoverageCollector` for the current platform."""
+    """Return a :class:`CoverageCollector` instance for the host system."""
     if platform.system() == "Darwin":
         return MacOSCollector()
     return LinuxCollector()

--- a/src/fz/coverage/cfg.py
+++ b/src/fz/coverage/cfg.py
@@ -1,38 +1,58 @@
+from typing import Dict, Iterable, Set, Tuple
+
+
 class ControlFlowGraph:
     """Simple directed graph built from basic block transitions."""
 
     def __init__(self) -> None:
-        # adjacency list mapping src -> {dst1, dst2, ...}
-        self.adj = {}
-        # execution count of each edge (src, dst)
-        self.edge_counts = {}
+        """Create an empty control flow graph."""
+        # adjacency list mapping ``src`` -> ``{dst1, dst2, ...}``
+        self.adj: Dict[int, Set[int]] = {}
+        # execution count of each edge ``(src, dst)``
+        self.edge_counts: Dict[Tuple[int, int], int] = {}
         # edges discovered via static analysis
-        self.possible_edges = set()
+        self.possible_edges: Set[Tuple[int, int]] = set()
 
-    def add_edges(self, edges):
-        """Add a sequence of (src, dst) edges to the graph."""
+    def add_edges(self, edges: Iterable[Tuple[int, int]]) -> None:
+        """Add executed edges to the graph and increment their counters.
+
+        Parameters
+        ----------
+        edges:
+            Iterable of ``(src, dst)`` edges that were observed during
+            execution.
+        """
         for src, dst in edges:
             self.adj.setdefault(src, set()).add(dst)
             key = (src, dst)
             self.edge_counts[key] = self.edge_counts.get(key, 0) + 1
 
-    def add_possible_edges(self, edges):
-        """Record statically discovered edges without incrementing counts."""
+    def add_possible_edges(self, edges: Iterable[Tuple[int, int]]) -> None:
+        """Record statically discovered edges without incrementing counts.
+
+        Parameters
+        ----------
+        edges:
+            Iterable of possible ``(src, dst)`` transitions.
+        """
         for src, dst in edges:
             self.adj.setdefault(src, set()).add(dst)
             self.possible_edges.add((src, dst))
 
-    def edge_count(self, edge):
+    def edge_count(self, edge: Tuple[int, int]) -> int:
+        """Return how many times ``edge`` was observed."""
         return self.edge_counts.get(edge, 0)
 
-    def new_edge_count(self, edges):
-        """Return how many edges in *edges* are new to the graph."""
+    def new_edge_count(self, edges: Iterable[Tuple[int, int]]) -> int:
+        """Return how many edges in ``edges`` are new to the graph."""
         return sum(1 for e in edges if e not in self.edge_counts)
 
-    def num_edges(self):
+    def num_edges(self) -> int:
+        """Return the number of unique executed edges."""
         return len(self.edge_counts)
 
-    def num_nodes(self):
+    def num_nodes(self) -> int:
+        """Return the number of unique nodes in the graph."""
         return len(self.adj)
 
     def to_dot(self) -> str:

--- a/src/fz/coverage/common.py
+++ b/src/fz/coverage/common.py
@@ -12,7 +12,24 @@ PTRACE_POKETEXT = 4
 
 
 def _ptrace(request: int, pid: int, addr: int = 0, data: int = 0) -> int:
-    """Wrapper around ``ptrace`` with errno handling."""
+    """Invoke ``ptrace`` and raise :class:`OSError` on failure.
+
+    Parameters
+    ----------
+    request:
+        The ``ptrace`` request number.
+    pid:
+        Process identifier of the traced process.
+    addr:
+        Address argument passed to ``ptrace``.
+    data:
+        Data argument passed to ``ptrace``.
+
+    Returns
+    -------
+    int
+        The raw return value from ``ptrace``.
+    """
     logging.debug(
         "ptrace request=%d pid=%d addr=%#x data=%#x",
         request,
@@ -28,7 +45,20 @@ def _ptrace(request: int, pid: int, addr: int = 0, data: int = 0) -> int:
 
 
 def _ptrace_peek(pid: int, addr: int) -> int:
-    """Read a word from ``pid`` at ``addr`` via ``ptrace``."""
+    """Read a word from ``pid`` at ``addr`` via ``ptrace``.
+
+    Parameters
+    ----------
+    pid:
+        Process identifier of the traced process.
+    addr:
+        Address to read from within the traced process.
+
+    Returns
+    -------
+    int
+        The value read from ``addr``.
+    """
     logging.debug("peek pid=%d addr=%#x", pid, addr)
     res = libc.ptrace(PTRACE_PEEKTEXT, pid, ctypes.c_void_p(addr), None)
     if res == -1:
@@ -39,7 +69,22 @@ def _ptrace_peek(pid: int, addr: int) -> int:
 
 
 def _ptrace_poke(pid: int, addr: int, data: int) -> int:
-    """Write a word to ``pid`` at ``addr`` via ``ptrace``."""
+    """Write a word to ``pid`` at ``addr`` via ``ptrace``.
+
+    Parameters
+    ----------
+    pid:
+        Process identifier of the traced process.
+    addr:
+        Address to write to.
+    data:
+        Value to write.
+
+    Returns
+    -------
+    int
+        The raw return value from ``ptrace``.
+    """
     logging.debug("poke pid=%d addr=%#x data=%#x", pid, addr, data)
     res = libc.ptrace(PTRACE_POKETEXT, pid, ctypes.c_void_p(addr), ctypes.c_void_p(data))
     if res != 0:

--- a/src/fz/coverage/macos.py
+++ b/src/fz/coverage/macos.py
@@ -9,6 +9,8 @@ import subprocess
 import time
 import errno
 
+from typing import Optional, Set, Tuple
+
 from .utils import get_basic_blocks
 from .common import _ptrace, _ptrace_peek, _ptrace_poke
 
@@ -32,7 +34,21 @@ set_pc = arch.set_pc
 
 
 
-def _get_image_base(pid, exe):
+def _get_image_base(pid: int, exe: str) -> int:
+    """Return the loaded base address for ``exe`` within ``pid``.
+
+    Parameters
+    ----------
+    pid:
+        Identifier of the process containing ``exe``.
+    exe:
+        Path to the executable on disk.
+
+    Returns
+    -------
+    int
+        The base address or ``0`` if not found.
+    """
     exe = os.path.realpath(exe)
     try:
         output = subprocess.check_output(["vmmap", str(pid)], text=True)
@@ -47,7 +63,27 @@ def _get_image_base(pid, exe):
     return 0
 
 
-def collect_coverage(pid, timeout=1.0, exe=None, already_traced=False):
+def collect_coverage(
+    pid: int, timeout: float = 1.0, exe: Optional[str] = None, already_traced: bool = False
+) -> Set[Tuple[int, int]]:
+    """Collect basic block transition coverage from a macOS process.
+
+    Parameters
+    ----------
+    pid:
+        Identifier of the process to trace.
+    timeout:
+        Maximum number of seconds to wait for coverage events.
+    exe:
+        Path to the executable. Must be provided on macOS.
+    already_traced:
+        Set to ``True`` if the caller has already attached using ``ptrace``.
+
+    Returns
+    -------
+    set[tuple[int, int]]
+        The executed basic block transitions.
+    """
     logging.debug("Collecting coverage for pid %d (macOS ptrace)", pid)
     coverage = set()
     prev_addr = None

--- a/src/fz/coverage/visualize.py
+++ b/src/fz/coverage/visualize.py
@@ -5,6 +5,7 @@ from .cfg import ControlFlowGraph
 
 
 def main() -> None:
+    """Entry point for the ``fz.coverage.visualize`` CLI."""
     parser = argparse.ArgumentParser(description="Visualize the control flow graph of a binary")
     parser.add_argument("binary", help="Path to the binary to analyze")
     group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
## Summary
- flesh out module documentation for coverage utilities
- add type hints and parameter/return docs in collector classes
- document helper functions throughout `fz.coverage`

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`

------
https://chatgpt.com/codex/tasks/task_e_684d753904a4832696189beab2b3c372