### PR TITLE
Add runtime fixture compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore compiled test binaries
+/tests/coverage/fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import subprocess
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture(scope="session")
+def tiny_binary(tmp_path_factory):
+    """Compile the small C coverage fixture and return its path."""
+    src = Path(__file__).parent / "coverage" / "fixture.c"
+    out_dir = tmp_path_factory.mktemp("bin")
+    exe = out_dir / "fixture"
+    subprocess.check_call(["cc", str(src), "-o", str(exe)])
+    exe.chmod(0o755)
+    return exe

--- a/tests/coverage/fixture.c
+++ b/tests/coverage/fixture.c
@@ -1,0 +1,2 @@
+int foo(int x) { if (x == 0) return 1; else return 2; }
+int main(int argc, char **argv) { return foo(argc); }

--- a/tests/coverage/test_collectors.py
+++ b/tests/coverage/test_collectors.py
@@ -1,0 +1,75 @@
+import ctypes
+import os
+import signal
+import pytest
+
+from fz.coverage.collector import (
+    LinuxCollector,
+    MacOSCollector,
+    PTRACE_GETREGS,
+    PTRACE_SETREGS,
+)
+from fz.coverage import collector as collector_module
+from fz.coverage.utils import get_basic_blocks
+from fz.arch import x86 as arch
+
+
+def _mock_environment(monkeypatch, blocks):
+    state = {"i": 0}
+
+    def fake_ptrace(request, pid, addr=0, data=0):
+        if request == PTRACE_GETREGS:
+            ctypes.cast(data, ctypes.POINTER(arch.user_regs_struct)).contents.rip = blocks[state["i"]] + 1
+        elif request == PTRACE_SETREGS:
+            state["i"] += 1
+        return 0
+
+    monkeypatch.setattr(collector_module, "_ptrace", fake_ptrace)
+    monkeypatch.setattr(collector_module, "_ptrace_peek", lambda pid, addr: 0)
+    monkeypatch.setattr(collector_module, "_ptrace_poke", lambda pid, addr, data: 0)
+    monkeypatch.setattr(os, "waitpid", lambda pid, opts: next(events))
+
+
+def test_linux_collector(monkeypatch, tiny_binary):
+    exe = str(tiny_binary)
+    blocks = get_basic_blocks(exe)
+    collector = LinuxCollector()
+
+    global events
+    events = iter([
+        (1234, (signal.SIGTRAP << 8) | 0x7F),
+        (1234, 0),
+        (1234, (signal.SIGTRAP << 8) | 0x7F),
+        (1234, 0),
+        (1234, 0),
+    ])
+
+    _mock_environment(monkeypatch, blocks)
+    monkeypatch.setattr(LinuxCollector, "_get_image_base", lambda self, pid, exe: 0)
+
+    edges = collector.collect_coverage(1234, exe=exe, already_traced=True)
+    assert edges == {(blocks[0], blocks[1])}
+
+
+def test_macos_collector(monkeypatch, tiny_binary):
+    exe = str(tiny_binary)
+    blocks = get_basic_blocks(exe)
+    collector = MacOSCollector()
+
+    global events
+    events = iter([
+        (1234, (signal.SIGTRAP << 8) | 0x7F),
+        (1234, 0),
+        (1234, (signal.SIGTRAP << 8) | 0x7F),
+        (1234, 0),
+        (1234, 0),
+    ])
+
+    _mock_environment(monkeypatch, blocks)
+    monkeypatch.setattr(MacOSCollector, "_get_image_base", lambda self, pid, exe: 0)
+
+    edges = collector.collect_coverage(1234, exe=exe, already_traced=True)
+    assert edges == {(blocks[0], blocks[1])}
+
+    with pytest.raises(RuntimeError):
+        collector.collect_coverage(1234, exe=None, already_traced=True)

--- a/tests/coverage/test_utils.py
+++ b/tests/coverage/test_utils.py
@@ -1,0 +1,17 @@
+import os
+from fz.coverage import utils
+
+
+def test_basic_blocks_and_edges_cached(tiny_binary):
+    exe = str(tiny_binary)
+    blocks1 = utils.get_basic_blocks(exe)
+    assert blocks1, "no blocks parsed"
+    blocks2 = utils.get_basic_blocks(exe)
+    assert blocks1 is blocks2
+    assert exe in utils._block_cache
+
+    edges1 = utils.get_possible_edges(exe)
+    assert edges1
+    edges2 = utils.get_possible_edges(exe)
+    assert edges1 is edges2
+    assert exe in utils._edge_cache


### PR DESCRIPTION
## Summary
- compile coverage test fixture at runtime instead of committing binary
- share compiled fixture via pytest session fixture
- update coverage tests to use compiled binary
- ignore compiled binaries in repo

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d781b86f48326bcce3a51238cf977