### PR TITLE
Add optional dependency rich

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 capstone
 pyelftools
 pyyaml
+rich
 


### PR DESCRIPTION
## Summary
- add missing optional dependency `rich` to `requirements.txt`

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d849a5c548326bffa25d09d0aa1e2