### PR TITLE
Add module-aware coverage edges

### DIFF
--- a/src/fz/corpus/mutator.py
+++ b/src/fz/corpus/mutator.py
@@ -36,7 +36,11 @@ class Mutator:
                 with open(path, "r") as f:
                     record = json.load(f)
                 data = base64.b64decode(record.get("data", ""))
-                coverage = [tuple(c) for c in record.get("coverage", [])]
+                coverage = [
+                    ((c[0], c[1]), (c[2], c[3]))
+                    for c in record.get("coverage", [])
+                    if len(c) == 4
+                ]
                 self.seeds.append(data)
                 self.seed_edges.append(coverage)
                 self.weights.append(max(1, len(coverage)))
@@ -118,7 +122,7 @@ class Mutator:
         seed = self._choose_seed()
         return self.mutate(seed)
 
-    def record_result(self, data: bytes, coverage: Set[int], interesting: bool) -> None:
+    def record_result(self, data: bytes, coverage: Set[tuple[tuple[str, int], tuple[str, int]]], interesting: bool) -> None:
         """Update seed pool based on the result of a fuzz iteration."""
         if interesting:
             self.seeds.append(data)

--- a/src/fz/harness/network.py
+++ b/src/fz/harness/network.py
@@ -22,10 +22,26 @@ class NetworkHarness:
         self.port = port
         self.udp = udp
 
-    def run(self, target, data, timeout, output_bytes=0):
+    def run(self, target, data, timeout, output_bytes=0, libs=None):
         """Start the target, send bytes over the network, and collect coverage.
 
-        Returns a tuple of (coverage_set, crashed, timed_out, stdout, stderr).
+        Parameters
+        ----------
+        target:
+            Executable path for the network service.
+        data:
+            Bytes to send after connecting.
+        timeout:
+            Seconds to wait for the service before killing it.
+        output_bytes:
+            Maximum amount of stdout/stderr to capture.
+        libs:
+            Optional list of library names to instrument for coverage.
+
+        Returns
+        -------
+        tuple
+            ``(coverage_set, crashed, timed_out, stdout, stderr)``
         """
         logging.debug("Launching network target: %s", target)
         stdout_file = tempfile.TemporaryFile()
@@ -62,7 +78,7 @@ class NetworkHarness:
             sock.close()
             collector = coverage.get_collector()
             coverage_set = collector.collect_coverage(
-                proc.pid, timeout, already_traced=True
+                proc.pid, timeout, already_traced=True, libs=libs
             )
             logging.debug("Collected %d coverage entries", len(coverage_set))
             try:

--- a/src/fz/runner/target.py
+++ b/src/fz/runner/target.py
@@ -4,7 +4,7 @@ import logging
 import os
 import subprocess
 import tempfile
-from typing import Set, Tuple
+from typing import Set, Tuple, Optional
 
 from fz import coverage
 
@@ -18,9 +18,10 @@ def run_target(
     timeout: float,
     file_input: bool = False,
     output_bytes: int = 0,
-) -> Tuple[Set[int], bool, bool, bytes, bytes]:
+    libs: Optional[list[str]] = None,
+) -> Tuple[Set[tuple[tuple[str, int], tuple[str, int]]], bool, bool, bytes, bytes]:
     """Execute *target* with *data* once and return execution results."""
-    coverage_set: Set[int] = set()
+    coverage_set: Set[tuple[tuple[str, int], tuple[str, int]]] = set()
     stdout_file = tempfile.TemporaryFile()
     stderr_file = tempfile.TemporaryFile()
     filename = None
@@ -65,7 +66,7 @@ def run_target(
         collector = coverage.get_collector()
         try:
             coverage_set = collector.collect_coverage(
-                proc.pid, timeout, target, already_traced=True
+                proc.pid, timeout, target, already_traced=True, libs=libs
             )
         except FileNotFoundError:
             logging.debug(


### PR DESCRIPTION
## Summary
- track basic block transitions with module identifiers to avoid address collisions
- update CFG and mutator to handle new edge format
- extend coverage collector to record module information
- adjust unit tests

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d87976b0c83268a3551867259015c