### PR TITLE
Handle delayed library loads

### DIFF
--- a/tests/coverage/test_collectors.py
+++ b/tests/coverage/test_collectors.py
@@ -29,6 +29,16 @@ def _mock_environment(monkeypatch, blocks):
     monkeypatch.setattr(collector_module, "_ptrace_poke", lambda pid, addr, data: 0)
     monkeypatch.setattr(os, "waitpid", lambda pid, opts: next(events))
 
+    def fake_wait_libs(self, pid, libs, timeout):
+        modules = []
+        for lib in libs:
+            path, base = self._find_library(pid, lib)
+            if path:
+                modules.append((path, base))
+        return modules
+
+    monkeypatch.setattr(collector_module.CoverageCollector, "_wait_for_libraries", fake_wait_libs)
+
 
 def test_linux_collector(monkeypatch, tiny_binary):
     exe = str(tiny_binary)


### PR DESCRIPTION
## Summary
- support waiting for instrumentation libraries to load
- handle dynamic library instrumentation in coverage collector tests

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684daac9d170832681ee6799a17f463f