### PR TITLE
Fix example fuzz scripts

### DIFF
--- a/examples/netserver/fuzz.sh
+++ b/examples/netserver/fuzz.sh
@@ -10,5 +10,5 @@ CORPUS_DIR="$(dirname "$0")/corpus"
 mkdir -p "$CORPUS_DIR"
 
 # Run the fuzzer using the TCP network harness
-python3 -m fz --target "$(dirname "$0")/server" --tcp 127.0.0.1 9000 \
+fz --target "$(dirname "$0")/server" --tcp 127.0.0.1 9000 \
     --iterations 10 --input-size 32 --corpus-dir "$CORPUS_DIR" --output-bytes 1024 "$@"

--- a/examples/target1/fuzz.sh
+++ b/examples/target1/fuzz.sh
@@ -10,5 +10,5 @@ CORPUS_DIR="$(dirname "$0")/corpus"
 mkdir -p "$CORPUS_DIR"
 
 # Run the fuzzer with a small number of iterations by default
-python3 ../../main.py --target "$(dirname "$0")/target1" --iterations 10 \
+fz --target "$(dirname "$0")/target1" --iterations 10 \
     --input-size 64 --corpus-dir "$CORPUS_DIR" --output-bytes 1024 "$@"

--- a/examples/target2/fuzz.sh
+++ b/examples/target2/fuzz.sh
@@ -11,5 +11,5 @@ mkdir -p "$CORPUS_DIR"
 
 # Run the fuzzer with a small number of iterations by default
 # Input size is 65 to accommodate "X" prefix + 64 bytes for the overflow
-python3 ../../main.py --target "$(dirname "$0")/target2" --iterations 10 \
+fz --target "$(dirname "$0")/target2" --iterations 10 \
     --input-size 65 --corpus-dir "$CORPUS_DIR" --output-bytes 1024 "$@"

--- a/examples/target4/fuzz.sh
+++ b/examples/target4/fuzz.sh
@@ -10,6 +10,6 @@ CORPUS_DIR="$(dirname "$0")/corpus"
 mkdir -p "$CORPUS_DIR"
 
 # Run the fuzzer using the TCP harness on port 9999
-python3 ../../main.py --target "$(dirname "$0")/target4" \
+fz --target "$(dirname "$0")/target4" \
     --tcp 127.0.0.1 9999 --iterations 10 --input-size 32 \
     --corpus-dir "$CORPUS_DIR" --output-bytes 1024 "$@"


### PR DESCRIPTION
## Summary
- update all example `fuzz.sh` scripts to use the `fz` CLI instead of the old main

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68501fa9a7f08326a8dcdcf25092d4e1