### PR TITLE
Update target4 to use preload network stub

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -55,4 +55,5 @@ crashes:
 
 Every connection stays open for a couple of seconds (longer when `WAIT` is
 received) so multiple clients can be connected simultaneously.
-Run `./fuzz.sh` to build the server and fuzz it using the network harness.
+Run `./fuzz.sh` to build the server and fuzz it using the new LD_PRELOAD
+network stub harness.

--- a/examples/target4/fuzz.sh
+++ b/examples/target4/fuzz.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Build the network server and run the Python fuzzer against it
+# Build the network server and run the Python fuzzer using the LD_PRELOAD stub
 set -e
 
 # Build the C program
@@ -9,7 +9,13 @@ make -C "$(dirname "$0")"
 CORPUS_DIR="$(dirname "$0")/corpus"
 mkdir -p "$CORPUS_DIR"
 
-# Run the fuzzer using the TCP harness on port 9999
+# Build the LD_PRELOAD network stub library
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+make -C "$ROOT_DIR/src/fz/harness/preload" clean all
+STUB_LIB="$ROOT_DIR/src/fz/harness/preload/build/libnet_stub.so"
+
+# Run the fuzzer using the LD_PRELOAD harness
 fz --target "$(dirname "$0")/target4" \
-    --tcp 127.0.0.1 9999 --iterations 10 --input-size 32 \
+    --preload "$STUB_LIB" --iterations 10 --input-size 32 \
     --corpus-dir "$CORPUS_DIR" --output-bytes 1024 "$@"
+

--- a/tests/harness/test_preload.py
+++ b/tests/harness/test_preload.py
@@ -33,9 +33,11 @@ def test_preload_harness(tmp_path):
     root = Path(__file__).resolve().parents[2]
     lib = build_stub(root)
     harness = PreloadHarness(str(lib))
+    target = build_target(tmp_path)
     cov, crashed, to, out, err = harness.run(str(target), b"ping", 1.0, output_bytes=10)
     assert not to
     assert isinstance(cov, set)
     cov, crashed, to, out, err = harness.run(str(target), b"OVERFLOW:AAAA", 1.0)
     assert crashed
+
 


### PR DESCRIPTION
## Summary
- build and load the `net_stub` LD_PRELOAD library when fuzzing example 4
- document the new harness in the examples README
- fix preload harness test to compile the target before running

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503adaaedc8326a617b6f2c641b2fa