### PR TITLE
Improve exit code handling

### DIFF
--- a/src/fz/__main__.py
+++ b/src/fz/__main__.py
@@ -34,14 +34,14 @@ class Fuzzer:
         """Execute target once and record coverage."""
         coverage_set = set()
         if network:
-            coverage_set, crashed, timed_out, stdout_data, stderr_data = network.run(
+            coverage_set, crashed, timed_out, exit_code, stdout_data, stderr_data = network.run(
                 target, data, timeout, self.corpus.output_bytes, libs=libs
             )
             logging.debug(
                 "Network run returned %d coverage entries", len(coverage_set)
             )
         else:
-            coverage_set, crashed, timed_out, stdout_data, stderr_data = run_target(
+            coverage_set, crashed, timed_out, exit_code, stdout_data, stderr_data = run_target(
                 target,
                 data,
                 timeout,
@@ -62,6 +62,7 @@ class Fuzzer:
                 prefix,
                 stdout_data,
                 stderr_data,
+                exit_code=exit_code,
             )
             if saved:
                 self.corpus.minimize_input(
@@ -74,7 +75,12 @@ class Fuzzer:
                 )
 
         interesting, path = self.corpus.save_input(
-            data, coverage_set, "interesting", stdout_data, stderr_data
+            data,
+            coverage_set,
+            "interesting",
+            stdout_data,
+            stderr_data,
+            exit_code=exit_code,
         )
         if interesting:
             self.corpus.minimize_input(

--- a/src/fz/harness/network.py
+++ b/src/fz/harness/network.py
@@ -41,7 +41,7 @@ class NetworkHarness:
         Returns
         -------
         tuple
-            ``(coverage_set, crashed, timed_out, stdout, stderr)``
+            ``(coverage_set, crashed, timed_out, exit_code, stdout, stderr)``
         """
         logging.debug("Launching network target: %s", target)
         stdout_file = tempfile.TemporaryFile()
@@ -72,6 +72,7 @@ class NetworkHarness:
 
         crashed = False
         timed_out = False
+        exit_code = None
         try:
             logging.debug("Sending %d bytes", len(data))
             sock.sendall(data)
@@ -83,7 +84,8 @@ class NetworkHarness:
             logging.debug("Collected %d coverage entries", len(coverage_set))
             try:
                 proc.wait(timeout=timeout)
-                crashed = proc.returncode not in (0, None)
+                exit_code = proc.returncode
+                crashed = exit_code is not None and exit_code < 0
             except subprocess.TimeoutExpired:
                 proc.kill()
                 timed_out = True
@@ -98,4 +100,4 @@ class NetworkHarness:
         stdout_file.close()
         stderr_file.close()
         logging.debug("Network run complete with %d coverage entries", len(coverage_set))
-        return coverage_set, crashed, timed_out, stdout_data, stderr_data
+        return coverage_set, crashed, timed_out, exit_code, stdout_data, stderr_data

--- a/src/fz/harness/preload/__init__.py
+++ b/src/fz/harness/preload/__init__.py
@@ -17,7 +17,14 @@ class PreloadHarness:
         timeout: float,
         output_bytes: int = 0,
         libs: Optional[list[str]] = None,
-    ) -> Tuple[Set[tuple], bool, bool, bytes, bytes]:
+    ) -> Tuple[Set[tuple], bool, bool, int | None, bytes, bytes]:
+        """Execute *target* under LD_PRELOAD and collect coverage.
+
+        Returns
+        -------
+        tuple
+            ``(coverage_set, crashed, timed_out, exit_code, stdout, stderr)``
+        """
         env = os.environ.copy()
         var = "DYLD_INSERT_LIBRARIES" if sys.platform == "darwin" else "LD_PRELOAD"
         env[var] = self.library

--- a/tests/harness/test_preload.py
+++ b/tests/harness/test_preload.py
@@ -34,10 +34,12 @@ def test_preload_harness(tmp_path):
     lib = build_stub(root)
     harness = PreloadHarness(str(lib))
     target = build_target(tmp_path)
-    cov, crashed, to, out, err = harness.run(str(target), b"ping", 1.0, output_bytes=10)
+    cov, crashed, to, rc, out, err = harness.run(str(target), b"ping", 1.0, output_bytes=10)
     assert not to
+    assert isinstance(rc, int)
     assert isinstance(cov, set)
-    cov, crashed, to, out, err = harness.run(str(target), b"OVERFLOW:AAAA", 1.0)
+    cov, crashed, to, rc, out, err = harness.run(str(target), b"OVERFLOW:AAAA", 1.0)
     assert crashed
+    assert rc is not None and rc < 0
 
 


### PR DESCRIPTION
## Summary
- include the process exit code when running targets
- only mark executions as crashed if a signal terminated the process
- save exit codes in the corpus and consider them in deduplication
- update preload/network harness interfaces
- adjust preload harness tests

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685170ef17448326b2fdc1bc4a6aa309