### PR TITLE
Fix crash saving logic

### DIFF
--- a/src/fz/corpus/corpus.py
+++ b/src/fz/corpus/corpus.py
@@ -71,6 +71,11 @@ class Corpus:
             self.coverage.update(coverage)
             self.coverage_hashes.add(cov_hash)
         else:
+            if not coverage - self.coverage:
+                logging.debug("Input did not yield new coverage")
+                self.coverage.update(coverage)
+                return False, None
+            self.coverage.update(coverage)
             filename = f"{category}-{int(time.time() * 1000)}.json"
             path = os.path.join(self.directory, filename)
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,0 +1,22 @@
+import os
+from fz.corpus.corpus import Corpus
+
+
+def test_crash_only_saved_on_new_coverage(tmp_path):
+    corpus = Corpus(str(tmp_path))
+    cov1 = {(1, 2, 3, 4)}
+    saved, path = corpus.save_input(b"A", cov1, "crash")
+    assert saved
+    assert os.path.exists(path)
+    assert len(os.listdir(tmp_path)) == 1
+
+    saved, path = corpus.save_input(b"B", cov1, "crash")
+    assert not saved
+    assert path is None
+    assert len(os.listdir(tmp_path)) == 1
+
+    cov2 = {(1, 2, 3, 4), (5, 6, 7, 8)}
+    saved, path = corpus.save_input(b"C", cov2, "crash")
+    assert saved
+    assert os.path.exists(path)
+    assert len(os.listdir(tmp_path)) == 2


### PR DESCRIPTION
## Summary
- only save crashing samples if they expand coverage
- test crash-saving behavior

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853086fb938832680c9ace059a1b424