### PR TITLE
Improve corpus file naming

### DIFF
--- a/src/fz/__main__.py
+++ b/src/fz/__main__.py
@@ -58,35 +58,21 @@ class Fuzzer:
                 "Run returned %d coverage entries", len(coverage_set)
             )
 
-        if crashed or timed_out:
-            prefix = "crash" if crashed else "timeout"
-            saved, orig = self.corpus.save_input(
-                data,
-                coverage_set,
-                prefix,
-                stdout_data,
-                stderr_data,
-                exit_code=exit_code,
-            )
-            if saved and self.minimize:
-                self.corpus.minimize_input(
-                    orig,
-                    target,
-                    timeout,
-                    file_input=file_input if not network else False,
-                    network=network if network else None,
-                    libs=libs,
-                )
+        category = "interesting"
+        if crashed:
+            category = "crash"
+        elif timed_out:
+            category = "timeout"
 
-        interesting, path = self.corpus.save_input(
+        saved, path = self.corpus.save_input(
             data,
             coverage_set,
-            "interesting",
+            category,
             stdout_data,
             stderr_data,
             exit_code=exit_code,
         )
-        if interesting and self.minimize:
+        if saved and self.minimize:
             self.corpus.minimize_input(
                 path,
                 target,
@@ -96,7 +82,7 @@ class Fuzzer:
                 libs=libs,
             )
         self.cfg.add_edges(coverage_set)
-        return interesting, coverage_set
+        return saved, coverage_set
 
     def _fuzz_loop(self, args, iter_counter=None, saved_counter=None):
 

--- a/src/fz/corpus/corpus.py
+++ b/src/fz/corpus/corpus.py
@@ -56,7 +56,8 @@ class Corpus:
             if exit_code is not None:
                 hash_input += f":{exit_code}".encode()
             cov_hash = hashlib.sha1(hash_input).hexdigest()
-            path = os.path.join(self.directory, cov_hash + ".json")
+            filename = cov_hash
+            path = os.path.join(self.directory, f"{category}-{filename}.json")
 
             if cov_hash in self.coverage_hashes or os.path.exists(path):
                 logging.debug("Input with identical coverage already stored")
@@ -76,8 +77,8 @@ class Corpus:
                 self.coverage.update(coverage)
                 return False, None
             self.coverage.update(coverage)
-            filename = f"{category}-{int(time.time() * 1000)}.json"
-            path = os.path.join(self.directory, filename)
+            filename = str(time.time_ns())
+            path = os.path.join(self.directory, f"{category}-{filename}.json")
 
         with open(path, "w") as f:
             json.dump(record, f)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -8,6 +8,7 @@ def test_crash_only_saved_on_new_coverage(tmp_path):
     saved, path = corpus.save_input(b"A", cov1, "crash")
     assert saved
     assert os.path.exists(path)
+    assert os.path.basename(path).startswith("crash-")
     assert len(os.listdir(tmp_path)) == 1
 
     saved, path = corpus.save_input(b"B", cov1, "crash")
@@ -19,4 +20,13 @@ def test_crash_only_saved_on_new_coverage(tmp_path):
     saved, path = corpus.save_input(b"C", cov2, "crash")
     assert saved
     assert os.path.exists(path)
+    assert os.path.basename(path).startswith("crash-")
     assert len(os.listdir(tmp_path)) == 2
+
+
+def test_interesting_prefix(tmp_path):
+    corpus = Corpus(str(tmp_path))
+    cov = {(1, 2, 3, 4)}
+    saved, path = corpus.save_input(b"A", cov, "interesting")
+    assert saved
+    assert os.path.basename(path).startswith("interesting-")


### PR DESCRIPTION
## Summary
- prefix every saved corpus sample with its reason
- simplify `_run_once` logic for saving results
- ensure unique timestamps for non-interesting saves
- test that crash and interesting samples include the reason in filenames

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530b330c788326b742f43b4606059b