### PR TITLE
Expose ptrace constants in coverage.common

### DIFF
--- a/src/fz/coverage/collector.py
+++ b/src/fz/coverage/collector.py
@@ -12,25 +12,23 @@ from abc import ABC, abstractmethod
 from typing import Optional, Set
 
 from .utils import get_basic_blocks
-from .common import _ptrace, _ptrace_peek, _ptrace_poke
+from .common import (
+    _ptrace,
+    _ptrace_peek,
+    _ptrace_poke,
+    PTRACE_ATTACH,
+    PTRACE_DETACH,
+    PTRACE_CONT,
+    PTRACE_SINGLESTEP,
+    PTRACE_GETREGS,
+    PTRACE_SETREGS,
+    BREAKPOINT,
+    user_regs_struct,
+    get_pc,
+    set_pc,
+)
 
 ARCH = platform.machine().lower()
-if ARCH in ("aarch64", "arm64"):
-    from ..arch import arm64 as arch
-else:
-    from ..arch import x86 as arch
-
-PTRACE_ATTACH = 16
-PTRACE_DETACH = 17
-PTRACE_CONT = 7
-PTRACE_SINGLESTEP = 9
-PTRACE_GETREGS = 12
-PTRACE_SETREGS = 13
-
-BREAKPOINT = arch.BREAKPOINT
-user_regs_struct = arch.user_regs_struct
-get_pc = arch.get_pc
-set_pc = arch.set_pc
 
 
 class CoverageCollector(ABC):

--- a/src/fz/coverage/common.py
+++ b/src/fz/coverage/common.py
@@ -2,6 +2,10 @@ import ctypes
 import ctypes.util
 import logging
 import os
+import platform
+
+from ..arch import arm64 as arm64_arch
+from ..arch import x86 as x86_arch
 
 libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
 libc.ptrace.argtypes = [ctypes.c_uint, ctypes.c_uint, ctypes.c_void_p, ctypes.c_void_p]
@@ -9,6 +13,24 @@ libc.ptrace.restype = ctypes.c_long
 
 PTRACE_PEEKTEXT = 1
 PTRACE_POKETEXT = 4
+
+PTRACE_ATTACH = 16
+PTRACE_DETACH = 17
+PTRACE_CONT = 7
+PTRACE_SINGLESTEP = 9
+PTRACE_GETREGS = 12
+PTRACE_SETREGS = 13
+
+ARCH = platform.machine().lower()
+if ARCH in ("aarch64", "arm64"):
+    arch_mod = arm64_arch
+else:
+    arch_mod = x86_arch
+
+BREAKPOINT = arch_mod.BREAKPOINT
+user_regs_struct = arch_mod.user_regs_struct
+get_pc = arch_mod.get_pc
+set_pc = arch_mod.set_pc
 
 
 def _ptrace(request: int, pid: int, addr: int = 0, data: int = 0) -> int:

--- a/src/fz/coverage/gdb_collector.py
+++ b/src/fz/coverage/gdb_collector.py
@@ -5,15 +5,9 @@ from typing import Optional, Set
 
 from .collector import CoverageCollector
 from .utils import get_basic_blocks
-from ..arch import arm64 as arm64_arch
-from ..arch import x86 as x86_arch
+from .common import BREAKPOINT
 
-ARCHS = {
-    "x86_64": x86_arch,
-    "amd64": x86_arch,
-    "aarch64": arm64_arch,
-    "arm64": arm64_arch,
-}
+_SUPPORTED_ARCHS = {"x86_64", "amd64", "aarch64", "arm64"}
 
 
 class GDBRemote:
@@ -100,10 +94,9 @@ class QemuGdbCollector(CoverageCollector):
         self.host = host
         self.port = port
         self.arch = arch
-        if arch not in ARCHS:
+        if arch not in _SUPPORTED_ARCHS:
             raise RuntimeError(f"Unsupported arch: {arch}")
-        self.arch_mod = ARCHS[arch]
-        self.BREAKPOINT = self.arch_mod.BREAKPOINT
+        self.BREAKPOINT = BREAKPOINT
 
     def _resolve_exe(self, pid: int, exe: Optional[str]) -> Optional[str]:
         return exe


### PR DESCRIPTION
## Summary
- centralize ptrace and architecture constants in `coverage.common`
- refactor collector modules to use the shared constants

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853149ba594832689bcd6b4f49dc7c6