### PR TITLE
Fix dedup logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ python3 -m fz --target ./target_arm64 --qemu-user qemu-aarch64 --arch arm64
 
 Coverage is gathered automatically using `ptrace`. The addresses recorded are
 normalized to the binary's load base so identical inputs yield identical
-coverage sets across runs. Inputs that execute new basic block transitions are stored in
+coverage sets across runs. Inputs that execute a unique set of basic block transitions are stored in
 the corpus directory. Use `--corpus-dir` to change
 where these inputs are saved. Basic block transition coverage via breakpoints is always
 enabled.
@@ -203,7 +203,7 @@ executed. The mutator weights seeds by the amount of coverage they produced and
 applies simple strategies such as bit flipping, splicing two seeds together,
 and inserting or deleting bytes. Each new input can be mutated multiple times in
 sequence (controlled by `--mutations`), allowing combinations of these
-operations. Whenever a run yields new coverage the input is added to the pool so
+operations. Whenever a run yields a unique coverage set the input is added to the pool so
 future mutations build on the most interesting cases.
 
 ## Fuzzing a Network Service

--- a/src/fz/corpus/corpus.py
+++ b/src/fz/corpus/corpus.py
@@ -3,7 +3,6 @@ import os
 import logging
 import json
 import base64
-import time
 import tempfile
 import subprocess
 from typing import Optional
@@ -12,7 +11,7 @@ from fz.runner.target import run_target
 
 
 class Corpus:
-    """Store inputs that produce new coverage."""
+    """Store inputs that exhibit unique coverage."""
 
     def __init__(self, directory: str = "corpus", output_bytes: int = 0):
         self.directory = directory
@@ -32,10 +31,9 @@ class Corpus:
     ):
         """Persist *data* and associated *coverage*.
 
-        If *category* is "interesting", coverage is deduplicated using a hash of
-        the coverage set.  For other categories (e.g. "crash" or "timeout") a
-        timestamped file name is used.  The saved file is JSON formatted and
-        compatible with the existing corpus structure.
+        Coverage is deduplicated using a hash of the coverage set regardless of
+        *category*.  Saved files are JSON formatted and compatible with the
+        existing corpus structure.
         """
 
         record = {
@@ -51,34 +49,24 @@ class Corpus:
         if category != "interesting":
             record["type"] = category
 
-        if category == "interesting":
-            hash_input = ",".join(str(c) for c in record["coverage"]).encode()
-            if exit_code is not None:
-                hash_input += f":{exit_code}".encode()
-            cov_hash = hashlib.sha1(hash_input).hexdigest()
-            filename = cov_hash
-            path = os.path.join(self.directory, f"{category}-{filename}.json")
+        hash_input = ",".join(str(c) for c in record["coverage"]).encode()
+        cov_hash = hashlib.sha1(hash_input).hexdigest()
+        filename = cov_hash
+        path = os.path.join(self.directory, f"{category}-{filename}.json")
 
-            if cov_hash in self.coverage_hashes or os.path.exists(path):
-                logging.debug("Input with identical coverage already stored")
-                self.coverage.update(coverage)
-                return False, None
+        existing = [
+            os.path.join(self.directory, f"interesting-{cov_hash}.json"),
+            os.path.join(self.directory, f"crash-{cov_hash}.json"),
+            os.path.join(self.directory, f"timeout-{cov_hash}.json"),
+        ]
 
-            if not coverage - self.coverage:
-                logging.debug("Input did not yield new coverage")
-                self.coverage.update(coverage)
-                return False, None
-
+        if cov_hash in self.coverage_hashes or any(os.path.exists(p) for p in existing):
+            logging.debug("Input with identical coverage already stored")
             self.coverage.update(coverage)
-            self.coverage_hashes.add(cov_hash)
-        else:
-            if not coverage - self.coverage:
-                logging.debug("Input did not yield new coverage")
-                self.coverage.update(coverage)
-                return False, None
-            self.coverage.update(coverage)
-            filename = str(time.time_ns())
-            path = os.path.join(self.directory, f"{category}-{filename}.json")
+            return False, None
+
+        self.coverage.update(coverage)
+        self.coverage_hashes.add(cov_hash)
 
         with open(path, "w") as f:
             json.dump(record, f)
@@ -130,7 +118,7 @@ class Corpus:
             return path
 
         def test_input(inp: bytes) -> bool:
-            """Run *inp* and store any new coverage.
+            """Run *inp* and store any coverage discovered.
 
             Returns ``True`` if the candidate still crashes or times out.
             """

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -2,7 +2,7 @@ import os
 from fz.corpus.corpus import Corpus
 
 
-def test_crash_only_saved_on_new_coverage(tmp_path):
+def test_crash_saved_on_unique_coverage(tmp_path):
     corpus = Corpus(str(tmp_path))
     cov1 = {(1, 2, 3, 4)}
     saved, path = corpus.save_input(b"A", cov1, "crash")
@@ -11,17 +11,27 @@ def test_crash_only_saved_on_new_coverage(tmp_path):
     assert os.path.basename(path).startswith("crash-")
     assert len(os.listdir(tmp_path)) == 1
 
+    # Duplicate coverage should not be saved
     saved, path = corpus.save_input(b"B", cov1, "crash")
     assert not saved
     assert path is None
     assert len(os.listdir(tmp_path)) == 1
 
+    # New combination introduces an additional edge
     cov2 = {(1, 2, 3, 4), (5, 6, 7, 8)}
     saved, path = corpus.save_input(b"C", cov2, "crash")
     assert saved
     assert os.path.exists(path)
     assert os.path.basename(path).startswith("crash-")
     assert len(os.listdir(tmp_path)) == 2
+
+    # Unique set composed of previously seen edges should also be saved
+    cov3 = {(5, 6, 7, 8)}
+    saved, path = corpus.save_input(b"D", cov3, "crash")
+    assert saved
+    assert os.path.exists(path)
+    assert os.path.basename(path).startswith("crash-")
+    assert len(os.listdir(tmp_path)) == 3
 
 
 def test_interesting_prefix(tmp_path):


### PR DESCRIPTION
## Summary
- dedupe corpus entries by coverage hash for all categories
- update tests for unique coverage behaviour
- document new behaviour

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530e3415a083269deaa31e2b3abe2f