### PR TITLE
Consolidate edge type

### DIFF
--- a/src/fz/corpus/mutator.py
+++ b/src/fz/corpus/mutator.py
@@ -4,6 +4,8 @@ import os
 import random
 from typing import List, Set, Iterable
 
+from fz.coverage.cfg import Edge
+
 from fz.coverage import ControlFlowGraph
 
 
@@ -122,7 +124,7 @@ class Mutator:
         seed = self._choose_seed()
         return self.mutate(seed)
 
-    def record_result(self, data: bytes, coverage: Set[tuple[tuple[str, int], tuple[str, int]]], interesting: bool) -> None:
+    def record_result(self, data: bytes, coverage: Set[Edge], interesting: bool) -> None:
         """Update seed pool based on the result of a fuzz iteration."""
         if interesting:
             self.seeds.append(data)

--- a/src/fz/coverage/collector.py
+++ b/src/fz/coverage/collector.py
@@ -11,6 +11,8 @@ from elftools.elf.elffile import ELFFile
 from abc import ABC, abstractmethod
 from typing import Optional, Set
 
+from .cfg import Edge
+
 from .utils import get_basic_blocks
 from .common import (
     _ptrace,
@@ -158,9 +160,9 @@ class CoverageCollector(ABC):
         breakpoints: dict,
         word_cache: dict,
         timeout: float,
-    ) -> Set[tuple[tuple[str, int], tuple[str, int]]]:
+    ) -> Set[Edge]:
         """Run the tracing loop until timeout and return collected edges."""
-        coverage: Set[tuple[tuple[str, int], tuple[str, int]]] = set()
+        coverage: Set[Edge] = set()
         prev_addr: Optional[tuple[str, int]] = None
         regs = user_regs_struct()
         _ptrace(PTRACE_CONT, pid)
@@ -218,7 +220,7 @@ class CoverageCollector(ABC):
         exe: Optional[str] = None,
         already_traced: bool = False,
         libs: Optional[list[str]] = None,
-    ) -> Set[tuple[tuple[str, int], tuple[str, int]]]:
+    ) -> Set[Edge]:
         """Collect basic block transition coverage from a traced process.
 
         Parameters
@@ -235,12 +237,12 @@ class CoverageCollector(ABC):
 
         Returns
         -------
-        set[tuple[tuple[str, int], tuple[str, int]]]
+        set[Edge]
             The set of executed basic block transitions as
             ``((module, src), (module, dst))`` pairs.
         """
         logging.debug("Collecting coverage for pid %d", pid)
-        coverage: Set[tuple[tuple[str, int], tuple[str, int]]] = set()
+        coverage: Set[Edge] = set()
         word_cache = {}
 
         exe = self._resolve_exe(pid, exe)

--- a/src/fz/coverage/gdb_collector.py
+++ b/src/fz/coverage/gdb_collector.py
@@ -3,6 +3,8 @@ import socket
 import time
 from typing import Optional, Set
 
+from .cfg import Edge
+
 from .collector import CoverageCollector
 from .utils import get_basic_blocks
 from .common import BREAKPOINT
@@ -114,7 +116,7 @@ class QemuGdbCollector(CoverageCollector):
         exe: Optional[str] = None,
         already_traced: bool = False,
         libs: Optional[list[str]] = None,
-    ) -> Set[tuple[tuple[str, int], tuple[str, int]]]:
+    ) -> Set[Edge]:
         if exe is None:
             raise RuntimeError("Executable path required")
         gdb = GDBRemote(self.host, self.port)
@@ -132,7 +134,7 @@ class QemuGdbCollector(CoverageCollector):
                 logging.debug("Failed to set breakpoint at %#x: %s", addr, e)
         gdb.continue_()
         end_time = time.time() + timeout * 2
-        coverage: Set[tuple[tuple[str, int], tuple[str, int]]] = set()
+        coverage: Set[Edge] = set()
         prev = None
         while time.time() < end_time:
             reason = gdb._recv_packet()

--- a/src/fz/coverage/utils.py
+++ b/src/fz/coverage/utils.py
@@ -2,10 +2,12 @@ import logging
 import os
 import platform
 
-from typing import List, Set, Tuple
+from typing import List, Set
 from capstone import Cs, CS_ARCH_X86, CS_ARCH_ARM64, CS_MODE_64, CS_MODE_ARM
 from capstone import CS_GRP_CALL, CS_GRP_JUMP, CS_GRP_RET, CS_OP_IMM
 from elftools.elf.elffile import ELFFile
+
+from .cfg import Edge
 
 _block_cache = {}
 _edge_cache = {}
@@ -90,7 +92,7 @@ def get_basic_blocks(exe: str) -> List[int]:
 
 
 
-def get_possible_edges(exe: str) -> Set[Tuple[Tuple[str, int], Tuple[str, int]]]:
+def get_possible_edges(exe: str) -> Set[Edge]:
     """Return a set of possible control flow edges for ``exe``.
 
     The edges are determined using a light-weight disassembly of the ``.text``
@@ -103,7 +105,7 @@ def get_possible_edges(exe: str) -> Set[Tuple[Tuple[str, int], Tuple[str, int]]]
 
     Returns
     -------
-    set[tuple[tuple[str, int], tuple[str, int]]]
+    set[Edge]
         All edges ``((module, src), (module, dst))`` that may be taken at runtime.
     """
     exe = os.path.realpath(exe)

--- a/src/fz/runner/target.py
+++ b/src/fz/runner/target.py
@@ -6,6 +6,8 @@ import subprocess
 import tempfile
 from typing import Set, Tuple, Optional
 
+from fz.coverage.cfg import Edge
+
 from fz import coverage
 
 libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
@@ -24,7 +26,7 @@ def run_target(
     arch: Optional[str] = None,
     env: Optional[dict[str, str]] = None,
 ) -> Tuple[
-    Set[tuple[tuple[str, int], tuple[str, int]]],
+    Set[Edge],
     bool,
     bool,
     int | None,
@@ -35,10 +37,10 @@ def run_target(
 
     Returns
     -------
-    Set[tuple], bool, bool, int | None, bytes, bytes
+    Set[Edge], bool, bool, int | None, bytes, bytes
         ``(coverage_set, crashed, timed_out, exit_code, stdout, stderr)``
     """
-    coverage_set: Set[tuple[tuple[str, int], tuple[str, int]]] = set()
+    coverage_set: Set[Edge] = set()
     exit_code: int | None = None
     stdout_file = tempfile.TemporaryFile()
     stderr_file = tempfile.TemporaryFile()


### PR DESCRIPTION
## Summary
- share `Edge` alias across coverage modules
- use the alias for return types

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68531fe71bb88326b535c113705a8415