### PR TITLE
Load corpus coverage

### DIFF
--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -40,3 +40,16 @@ def test_interesting_prefix(tmp_path):
     saved, path = corpus.save_input(b"A", cov, "interesting")
     assert saved
     assert os.path.basename(path).startswith("interesting-")
+
+
+def test_load_existing_coverage(tmp_path):
+    corpus = Corpus(str(tmp_path))
+    cov = {(1, 2, 3, 4)}
+    saved, path = corpus.save_input(b"A", cov)
+    assert saved
+
+    # New instance should load existing coverage and avoid duplicates
+    corpus2 = Corpus(str(tmp_path))
+    saved, path = corpus2.save_input(b"B", cov)
+    assert not saved
+    assert path is None


### PR DESCRIPTION
## Summary
- load coverage and hashes when `Corpus` is created
- ensure deduplication works across restarts
- test that reloading works

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853235648748326ac16097abf0b7f20