### PR TITLE
Fix corpus stats and improve status reporting

### DIFF
--- a/src/fz/__main__.py
+++ b/src/fz/__main__.py
@@ -221,9 +221,9 @@ class Fuzzer:
                     if make_table is None:
                         return (
                             f"iters={iters} saved={saves} rate={rate:.2f}/sec "
-                            f"corpus={samples} edges={edges_str}"
+                            f"corpus={samples} edges={edges}"
                         )
-                    return make_table(iters, saves, rate, samples, edges_str)
+                    return make_table(iters, saves, rate, samples, edges)
 
                 if Live:
                     with Live(snapshot(), refresh_per_second=1) as live:
@@ -259,7 +259,15 @@ class Fuzzer:
 
             return
 
-        self._fuzz_loop(args)
+        stats = self._fuzz_loop(args)
+        from fz.corpus.corpus import corpus_stats
+        from fz.coverage import get_possible_edges
+
+        samples, covered = corpus_stats(args.corpus_dir)
+        total_edges = len(get_possible_edges(args.target))
+        logging.info("Corpus entries: %d (+%d new)", samples, stats.get("saved", 0))
+        edge_info = f"{covered}/{total_edges}" if total_edges else str(covered)
+        logging.info("Unique coverage edges: %s", edge_info)
 
 
 def _worker(args, iter_counter=None, saved_counter=None):

--- a/src/fz/corpus/corpus.py
+++ b/src/fz/corpus/corpus.py
@@ -37,7 +37,15 @@ class Corpus:
             try:
                 with open(path) as f:
                     record = json.load(f)
-                edges = {tuple(e) for e in record.get("coverage", []) if len(e) == 4}
+                edges = set()
+                for c in record.get("coverage", []):
+                    if (
+                        isinstance(c, (list, tuple))
+                        and len(c) == 2
+                        and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in c)
+                    ):
+                        edge = (tuple(c[0]), tuple(c[1]))
+                        edges.add(edge)
             except Exception:
                 continue
             self.coverage.update(edges)
@@ -219,7 +227,14 @@ def corpus_stats(directory: str) -> tuple[int, int]:
         try:
             with open(path) as f:
                 record = json.load(f)
-            edges.update(tuple(e) for e in record.get("coverage", []))
+            for c in record.get("coverage", []):
+                if (
+                    isinstance(c, (list, tuple))
+                    and len(c) == 2
+                    and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in c)
+                ):
+                    edge = (tuple(c[0]), tuple(c[1]))
+                    edges.add(edge)
             entries += 1
         except Exception:
             continue

--- a/src/fz/corpus/mutator.py
+++ b/src/fz/corpus/mutator.py
@@ -38,11 +38,15 @@ class Mutator:
                 with open(path, "r") as f:
                     record = json.load(f)
                 data = base64.b64decode(record.get("data", ""))
-                coverage = [
-                    ((c[0], c[1]), (c[2], c[3]))
-                    for c in record.get("coverage", [])
-                    if len(c) == 4
-                ]
+                coverage = []
+                for c in record.get("coverage", []):
+                    if (
+                        isinstance(c, (list, tuple))
+                        and len(c) == 2
+                        and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in c)
+                    ):
+                        edge = (tuple(c[0]), tuple(c[1]))
+                        coverage.append(edge)
                 self.seeds.append(data)
                 self.seed_edges.append(coverage)
                 self.weights.append(max(1, len(coverage)))

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -4,7 +4,7 @@ from fz.corpus.corpus import Corpus
 
 def test_crash_saved_on_unique_coverage(tmp_path):
     corpus = Corpus(str(tmp_path))
-    cov1 = {(1, 2, 3, 4)}
+    cov1 = {(('mod', 1), ('mod', 2))}
     saved, path = corpus.save_input(b"A", cov1, "crash")
     assert saved
     assert os.path.exists(path)
@@ -18,7 +18,7 @@ def test_crash_saved_on_unique_coverage(tmp_path):
     assert len(os.listdir(tmp_path)) == 1
 
     # New combination introduces an additional edge
-    cov2 = {(1, 2, 3, 4), (5, 6, 7, 8)}
+    cov2 = {(('mod', 1), ('mod', 2)), (('mod', 3), ('mod', 4))}
     saved, path = corpus.save_input(b"C", cov2, "crash")
     assert saved
     assert os.path.exists(path)
@@ -26,7 +26,7 @@ def test_crash_saved_on_unique_coverage(tmp_path):
     assert len(os.listdir(tmp_path)) == 2
 
     # Unique set composed of previously seen edges should also be saved
-    cov3 = {(5, 6, 7, 8)}
+    cov3 = {(('mod', 3), ('mod', 4))}
     saved, path = corpus.save_input(b"D", cov3, "crash")
     assert saved
     assert os.path.exists(path)
@@ -36,7 +36,7 @@ def test_crash_saved_on_unique_coverage(tmp_path):
 
 def test_interesting_prefix(tmp_path):
     corpus = Corpus(str(tmp_path))
-    cov = {(1, 2, 3, 4)}
+    cov = {(('mod', 1), ('mod', 2))}
     saved, path = corpus.save_input(b"A", cov, "interesting")
     assert saved
     assert os.path.basename(path).startswith("interesting-")
@@ -44,7 +44,7 @@ def test_interesting_prefix(tmp_path):
 
 def test_load_existing_coverage(tmp_path):
     corpus = Corpus(str(tmp_path))
-    cov = {(1, 2, 3, 4)}
+    cov = {(('mod', 1), ('mod', 2))}
     saved, path = corpus.save_input(b"A", cov)
     assert saved
 
@@ -53,3 +53,4 @@ def test_load_existing_coverage(tmp_path):
     saved, path = corpus2.save_input(b"B", cov)
     assert not saved
     assert path is None
+


### PR DESCRIPTION
## Summary
- handle nested coverage lists in `Corpus` utilities
- show coverage metrics in single-process fuzzing output
- fix status update variable name

## Testing
- `python -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854bc5133108326bae4e0581f1f6484