### PR TITLE
Normalize coverage offsets

### DIFF
--- a/src/fz/coverage/utils.py
+++ b/src/fz/coverage/utils.py
@@ -122,7 +122,7 @@ def get_basic_blocks(exe: str) -> List[int]:
     prev_branch = True
     for insn in md.disasm(text, base):
         if prev_branch:
-            blocks.add(insn.address)
+            blocks.add(insn.address - base)
         is_branch = (
             CS_GRP_JUMP in insn.groups
             or CS_GRP_RET in insn.groups


### PR DESCRIPTION
## Summary
- normalize basic block addresses by subtracting `.text` base
- compute breakpoint and entry addresses using text base
- fix tests for new relative offsets

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c5eebe948326b83c48f4f19b45d0