### PR TITLE
Introduce decode_coverage helper

### DIFF
--- a/src/fz/corpus/__init__.py
+++ b/src/fz/corpus/__init__.py
@@ -1,0 +1,6 @@
+"""Corpus utilities and helpers."""
+
+from .utils import decode_coverage
+
+__all__ = ["decode_coverage"]
+

--- a/src/fz/corpus/corpus.py
+++ b/src/fz/corpus/corpus.py
@@ -7,6 +7,8 @@ import tempfile
 import subprocess
 from typing import Optional
 
+from .utils import decode_coverage
+
 from fz.runner.target import run_target
 
 
@@ -37,15 +39,7 @@ class Corpus:
             try:
                 with open(path) as f:
                     record = json.load(f)
-                edges = set()
-                for c in record.get("coverage", []):
-                    if (
-                        isinstance(c, (list, tuple))
-                        and len(c) == 2
-                        and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in c)
-                    ):
-                        edge = (tuple(c[0]), tuple(c[1]))
-                        edges.add(edge)
+                edges = decode_coverage(record.get("coverage", []))
             except Exception:
                 continue
             self.coverage.update(edges)
@@ -227,14 +221,7 @@ def corpus_stats(directory: str) -> tuple[int, int]:
         try:
             with open(path) as f:
                 record = json.load(f)
-            for c in record.get("coverage", []):
-                if (
-                    isinstance(c, (list, tuple))
-                    and len(c) == 2
-                    and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in c)
-                ):
-                    edge = (tuple(c[0]), tuple(c[1]))
-                    edges.add(edge)
+            edges.update(decode_coverage(record.get("coverage", [])))
             entries += 1
         except Exception:
             continue

--- a/src/fz/corpus/mutator.py
+++ b/src/fz/corpus/mutator.py
@@ -7,6 +7,7 @@ from typing import List, Set, Iterable
 from fz.coverage.cfg import Edge
 
 from fz.coverage import ControlFlowGraph
+from .utils import decode_coverage
 
 
 class Mutator:
@@ -38,15 +39,7 @@ class Mutator:
                 with open(path, "r") as f:
                     record = json.load(f)
                 data = base64.b64decode(record.get("data", ""))
-                coverage = []
-                for c in record.get("coverage", []):
-                    if (
-                        isinstance(c, (list, tuple))
-                        and len(c) == 2
-                        and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in c)
-                    ):
-                        edge = (tuple(c[0]), tuple(c[1]))
-                        coverage.append(edge)
+                coverage = list(decode_coverage(record.get("coverage", [])))
                 self.seeds.append(data)
                 self.seed_edges.append(coverage)
                 self.weights.append(max(1, len(coverage)))

--- a/src/fz/corpus/utils.py
+++ b/src/fz/corpus/utils.py
@@ -1,0 +1,16 @@
+from typing import Iterable, Set
+
+from fz.coverage.cfg import Edge
+
+
+def decode_coverage(coverage: Iterable) -> Set[Edge]:
+    """Return ``coverage`` decoded as a set of edges."""
+    edges: Set[Edge] = set()
+    for c in coverage or []:
+        if (
+            isinstance(c, (list, tuple))
+            and len(c) == 2
+            and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in c)
+        ):
+            edges.add((tuple(c[0]), tuple(c[1])))
+    return edges

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,5 +1,6 @@
 import os
 from fz.corpus.corpus import Corpus
+from fz.corpus import decode_coverage
 
 
 def test_crash_saved_on_unique_coverage(tmp_path):
@@ -53,4 +54,13 @@ def test_load_existing_coverage(tmp_path):
     saved, path = corpus2.save_input(b"B", cov)
     assert not saved
     assert path is None
+
+
+def test_decode_coverage_helper():
+    cov_list = [[["mod", 1], ["mod", 2]], [["mod", 3], ["mod", 4]]]
+    edges = decode_coverage(cov_list)
+    assert edges == {
+        (("mod", 1), ("mod", 2)),
+        (("mod", 3), ("mod", 4)),
+    }
 


### PR DESCRIPTION
## Summary
- add `decode_coverage` helper for reading corpus coverage
- use `decode_coverage` in Corpus, Mutator and corpus_stats
- test the new helper

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c748eea48326af4b67e0126571a7