### PR TITLE
Fix empty corpus seeding

### DIFF
--- a/src/fz/corpus/mutator.py
+++ b/src/fz/corpus/mutator.py
@@ -46,12 +46,12 @@ class Mutator:
             except Exception:
                 continue
         if not self.seeds:
-            # Ensure at least one seed exists to mutate
-            self.seeds.append(os.urandom(self.input_size))
+            # Use a null seed when no corpus inputs are present
+            self.seeds.append(b"")
             self.seed_edges.append([])
             self.weights.append(1)
-        # Always include an empty seed for minimal mutations
-        if b"" not in self.seeds:
+        elif b"" not in self.seeds:
+            # Always include an empty seed for minimal mutations
             self.seeds.append(b"")
             self.seed_edges.append([])
             self.weights.append(1)

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -1,0 +1,9 @@
+import os
+from fz.corpus.mutator import Mutator
+
+
+def test_empty_corpus_uses_null_seed(tmp_path):
+    m = Mutator(corpus_dir=str(tmp_path), input_size=8)
+    assert m.seeds == [b""]
+    assert m.seed_edges == [[]]
+    assert m.weights == [1]


### PR DESCRIPTION
## Summary
- ensure Mutator only adds a null seed when the corpus is empty
- add regression test for this behavior

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b637fc08832685e1513604daae30