### PR TITLE
Cache seed weights in mutator

### DIFF
--- a/src/fz/corpus/mutator.py
+++ b/src/fz/corpus/mutator.py
@@ -2,7 +2,7 @@ import base64
 import json
 import os
 import random
-from typing import List, Set, Iterable
+from typing import Iterable, List, Set
 
 from fz.coverage.cfg import Edge
 
@@ -28,6 +28,17 @@ class Mutator:
         self.seed_edges: List[Iterable[tuple]] = []
         self.weights: List[int] = []
         self._load_corpus()
+        self._update_weights()
+
+    def _update_weights(self) -> None:
+        """Recalculate seed selection weights based on unseen edge counts."""
+        self.weights = []
+        for edges in self.seed_edges:
+            if self.cfg:
+                unseen = self.cfg.new_edge_count(edges)
+                self.weights.append(max(1, unseen))
+            else:
+                self.weights.append(max(1, len(edges)))
 
     def _load_corpus(self) -> None:
         """Load saved inputs from the corpus directory."""
@@ -42,28 +53,19 @@ class Mutator:
                 coverage = list(decode_coverage(record.get("coverage", [])))
                 self.seeds.append(data)
                 self.seed_edges.append(coverage)
-                self.weights.append(max(1, len(coverage)))
             except Exception:
                 continue
         if not self.seeds:
             # Use a null seed when no corpus inputs are present
             self.seeds.append(b"")
             self.seed_edges.append([])
-            self.weights.append(1)
         elif b"" not in self.seeds:
             # Always include an empty seed for minimal mutations
             self.seeds.append(b"")
             self.seed_edges.append([])
-            self.weights.append(1)
 
     # ---- mutation helpers ----
     def _choose_seed(self) -> bytes:
-        if self.cfg:
-            weights = []
-            for edges in self.seed_edges:
-                unseen = self.cfg.new_edge_count(edges)
-                weights.append(max(1, unseen))
-            return random.choices(self.seeds, weights=weights, k=1)[0]
         return random.choices(self.seeds, weights=self.weights, k=1)[0]
 
     def _bitflip(self, data: bytearray) -> bytearray:
@@ -126,5 +128,5 @@ class Mutator:
         if interesting:
             self.seeds.append(data)
             self.seed_edges.append(list(coverage))
-            self.weights.append(max(1, len(coverage)))
+            self._update_weights()
 

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -1,5 +1,6 @@
-import os
+from fz.corpus.corpus import Corpus
 from fz.corpus.mutator import Mutator
+from fz.coverage import ControlFlowGraph
 
 
 def test_empty_corpus_uses_null_seed(tmp_path):
@@ -7,3 +8,29 @@ def test_empty_corpus_uses_null_seed(tmp_path):
     assert m.seeds == [b""]
     assert m.seed_edges == [[]]
     assert m.weights == [1]
+
+
+def test_weights_update_on_new_edges(tmp_path):
+    cfg = ControlFlowGraph()
+    corpus_dir = str(tmp_path)
+    corpus = Corpus(corpus_dir)
+
+    cov1 = {(('mod', 1), ('mod', 2)), (('mod', 2), ('mod', 3))}
+    cov2 = {(('mod', 3), ('mod', 4))}
+
+    corpus.save_input(b'A', cov1)
+    corpus.save_input(b'B', cov2)
+
+    m = Mutator(corpus_dir=corpus_dir, input_size=8, cfg=cfg)
+
+    assert sorted(m.weights) == [1, 1, 2]
+
+    cfg.add_edges(cov1)
+    m.record_result(b'A', cov1, interesting=False)
+    assert sorted(m.weights) == [1, 1, 2]
+
+    new_cov = {(('mod', 4), ('mod', 5))}
+    cfg.add_edges(new_cov)
+    m.record_result(b'C', new_cov, interesting=True)
+
+    assert all(w == 1 for w in m.weights)


### PR DESCRIPTION
## Summary
- cache unseen edge weights for seeds
- update weight cache only when new seeds are added
- use cached weights to choose seeds
- test that weight cache updates when new edges appear

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b809b8788326b50df505e109f90c