### PR TITLE
Avoid temp files when output not captured

### DIFF
--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,0 +1,27 @@
+import tempfile
+import os
+import fz.coverage as coverage
+from fz.runner.target import run_target
+
+
+def test_run_target_no_tempfile(monkeypatch):
+    calls = {"count": 0}
+    orig_tmpfile = tempfile.TemporaryFile
+
+    def fake_tmpfile(*args, **kwargs):
+        calls["count"] += 1
+        return orig_tmpfile(*args, **kwargs)
+
+    monkeypatch.setattr(tempfile, "TemporaryFile", fake_tmpfile)
+
+    class DummyCollector:
+        def collect_coverage(self, *args, **kwargs):
+            return set()
+
+    monkeypatch.setattr(coverage, "get_collector", lambda: DummyCollector())
+
+    cov, crashed, to, rc, out, err = run_target("/usr/bin/true", b"", 1.0, output_bytes=0)
+    assert cov == set()
+    assert calls["count"] == 0
+    assert out == b""
+    assert err == b""


### PR DESCRIPTION
## Summary
- avoid allocating temporary files in `run_target` when no output capture is requested
- read and close temporary files only when capturing output
- add unit test to ensure no temporary files are created when `output_bytes` is zero

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b9addb008326bf4eb78f60e52156