### PR TITLE
Track non-empty seeds for efficient splicing

### DIFF
--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -34,3 +34,21 @@ def test_weights_update_on_new_edges(tmp_path):
     m.record_result(b'C', new_cov, interesting=True)
 
     assert all(w == 1 for w in m.weights)
+
+
+def test_non_empty_seed_tracking(tmp_path):
+    corpus_dir = str(tmp_path)
+    corpus = Corpus(corpus_dir)
+
+    cov = {(('mod', 1), ('mod', 2))}
+    corpus.save_input(b'A', cov)
+
+    m = Mutator(corpus_dir=corpus_dir, input_size=8)
+
+    assert b"" in m.seeds
+    assert m.non_empty_seeds == [b"A"]
+
+    m.record_result(b"B", cov, interesting=True)
+    assert b"B" in m.non_empty_seeds
+    m.record_result(b"C", cov, interesting=False)
+    assert b"C" not in m.non_empty_seeds


### PR DESCRIPTION
## Summary
- keep track of non-empty seeds in `Mutator`
- maintain this list when loading the corpus or recording results
- use the list in `_splice`
- test new behaviour

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855bac98dec8326a83c757cd55a8c8e