### PR TITLE
Add seed directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Write input to a file:
 fz --target /path/to/binary --file-input --iterations 100
 ```
 
+Provide initial seeds from a directory:
+
+```bash
+fz --target /path/to/binary --seed-dir ./seeds
+```
+
 Fuzz a network service:
 
 ```bash
@@ -166,6 +172,7 @@ coverage sets across runs. Inputs that execute a unique set of basic block trans
 the corpus directory. Use `--corpus-dir` to change
 where these inputs are saved. Basic block transition coverage via breakpoints is always
 enabled.
+Provide `--seed-dir` to load an initial set of files as seeds.
 
 Each saved input is keyed by a hash of the coverage it produced. Samples are
 written as JSON files containing the executed basic block transitions, the input bytes

--- a/src/fz/__main__.py
+++ b/src/fz/__main__.py
@@ -115,7 +115,13 @@ class Fuzzer:
         i = 0
         saved = 0
         from fz.corpus.mutator import Mutator
-        mutator = Mutator(args.corpus_dir, args.input_size, args.mutations, cfg=self.cfg)
+        mutator = Mutator(
+            args.corpus_dir,
+            args.input_size,
+            args.mutations,
+            cfg=self.cfg,
+            seed_dir=args.seed_dir,
+        )
         try:
             while True:
                 data = mutator.next_input()
@@ -375,6 +381,10 @@ def parse_args():
         "--corpus-dir",
         default="corpus",
         help="Directory to store interesting test cases",
+    )
+    parser.add_argument(
+        "--seed-dir",
+        help="Directory of initial seed files",
     )
     parser.add_argument(
         "--minimize",

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -52,3 +52,18 @@ def test_non_empty_seed_tracking(tmp_path):
     assert b"B" in m.non_empty_seeds
     m.record_result(b"C", cov, interesting=False)
     assert b"C" not in m.non_empty_seeds
+
+
+def test_seed_directory_inputs(tmp_path):
+    corpus_dir = tmp_path / "corpus"
+    seed_dir = tmp_path / "seeds"
+    corpus_dir.mkdir()
+    seed_dir.mkdir()
+    (seed_dir / "one").write_bytes(b"A")
+    (seed_dir / "two").write_bytes(b"BB")
+
+    m = Mutator(corpus_dir=str(corpus_dir), input_size=8, seed_dir=str(seed_dir))
+
+    assert b"A" in m.seeds
+    assert b"BB" in m.seeds
+    assert b"" in m.seeds


### PR DESCRIPTION
## Summary
- allow specifying a directory of seed files with `--seed-dir`
- support loading seed files in the mutator
- document the new option and add example usage
- test seed directory handling

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c6852540832685b77ed5096f511a