### PR TITLE
Organize corpus outputs by category

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,14 @@ enabled.
 Provide `--seed-dir` to load an initial set of files as seeds.
 
 Each saved input is keyed by a hash of the coverage it produced. Samples are
-written as JSON files containing the executed basic block transitions, the input bytes
-(base64 encoded), and optionally the first N bytes of stdout/stderr from the
-target. Use `--output-bytes` to set how much output to store. Because filenames
-are derived from the coverage hash,
-parallel fuzzing only keeps the first input for a given coverage set,
-preventing duplicate samples that exercise the same code paths.
+written as JSON files containing the executed basic block transitions, the input
+bytes (base64 encoded), and optionally the first N bytes of stdout/stderr from
+the target. Use `--output-bytes` to set how much output to store. Saved files are
+organized by why the input was kept. The corpus directory contains subfolders
+such as `crash`, `timeout`, and `interesting`, each storing files named only
+with the coverage hash. Because filenames are derived from the hash, parallel
+fuzzing only keeps the first input for a given coverage set, preventing
+duplicate samples that exercise the same code paths.
 
 ```bash
 python3 -m fz --target /path/to/binary --iterations 100 --corpus-dir ./out

--- a/src/fz/corpus/manager.py
+++ b/src/fz/corpus/manager.py
@@ -18,9 +18,10 @@ def _iter_samples(directory: str) -> Iterable[str]:
     """Yield full paths to JSON corpus entries in *directory*."""
     if not os.path.isdir(directory):
         return []
-    for name in sorted(os.listdir(directory)):
-        if name.endswith('.json'):
-            yield os.path.join(directory, name)
+    for root, _, files in os.walk(directory):
+        for name in sorted(files):
+            if name.endswith('.json'):
+                yield os.path.join(root, name)
 
 
 def _decode_field(value: str) -> str:
@@ -49,7 +50,8 @@ def _analyze(args) -> None:
 
 
 def _add(args) -> None:
-    os.makedirs(args.corpus_dir, exist_ok=True)
+    manual_dir = os.path.join(args.corpus_dir, "manual")
+    os.makedirs(manual_dir, exist_ok=True)
     with open(args.file, "rb") as f:
         data = f.read()
     record = {
@@ -57,8 +59,8 @@ def _add(args) -> None:
         "coverage": [],
         "type": "manual",
     }
-    name = f"manual-{int(time.time() * 1000)}.json"
-    path = os.path.join(args.corpus_dir, name)
+    name = f"{int(time.time() * 1000)}.json"
+    path = os.path.join(manual_dir, name)
     with open(path, "w") as f:
         json.dump(record, f)
     print(path)

--- a/src/fz/corpus/mutator.py
+++ b/src/fz/corpus/mutator.py
@@ -49,19 +49,22 @@ class Mutator:
         """Load saved inputs from the corpus directory."""
         if not os.path.isdir(self.corpus_dir):
             return
-        for name in os.listdir(self.corpus_dir):
-            path = os.path.join(self.corpus_dir, name)
-            try:
-                with open(path, "r") as f:
-                    record = json.load(f)
-                data = base64.b64decode(record.get("data", ""))
-                coverage = list(decode_coverage(record.get("coverage", [])))
-                self.seeds.append(data)
-                self.seed_edges.append(coverage)
-                if data:
-                    self.non_empty_seeds.append(data)
-            except Exception:
-                continue
+        for root, _, files in os.walk(self.corpus_dir):
+            for name in files:
+                path = os.path.join(root, name)
+                if not path.endswith(".json"):
+                    continue
+                try:
+                    with open(path, "r") as f:
+                        record = json.load(f)
+                    data = base64.b64decode(record.get("data", ""))
+                    coverage = list(decode_coverage(record.get("coverage", [])))
+                    self.seeds.append(data)
+                    self.seed_edges.append(coverage)
+                    if data:
+                        self.non_empty_seeds.append(data)
+                except Exception:
+                    continue
         return
 
     def _load_seed_dir(self) -> None:

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from fz.corpus.corpus import Corpus
 from fz.corpus import decode_coverage
 
@@ -9,30 +10,32 @@ def test_crash_saved_on_unique_coverage(tmp_path):
     saved, path = corpus.save_input(b"A", cov1, "crash")
     assert saved
     assert os.path.exists(path)
-    assert os.path.basename(path).startswith("crash-")
-    assert len(os.listdir(tmp_path)) == 1
+    crash_dir = Path(tmp_path) / "crash"
+    assert crash_dir.is_dir()
+    assert crash_dir in Path(path).parents
+    assert len(list(crash_dir.iterdir())) == 1
 
     # Duplicate coverage should not be saved
     saved, path = corpus.save_input(b"B", cov1, "crash")
     assert not saved
     assert path is None
-    assert len(os.listdir(tmp_path)) == 1
+    assert len(list(crash_dir.iterdir())) == 1
 
     # New combination introduces an additional edge
     cov2 = {(('mod', 1), ('mod', 2)), (('mod', 3), ('mod', 4))}
     saved, path = corpus.save_input(b"C", cov2, "crash")
     assert saved
     assert os.path.exists(path)
-    assert os.path.basename(path).startswith("crash-")
-    assert len(os.listdir(tmp_path)) == 2
+    assert crash_dir in Path(path).parents
+    assert len(list(crash_dir.iterdir())) == 2
 
     # Unique set composed of previously seen edges should also be saved
     cov3 = {(('mod', 3), ('mod', 4))}
     saved, path = corpus.save_input(b"D", cov3, "crash")
     assert saved
     assert os.path.exists(path)
-    assert os.path.basename(path).startswith("crash-")
-    assert len(os.listdir(tmp_path)) == 3
+    assert crash_dir in Path(path).parents
+    assert len(list(crash_dir.iterdir())) == 3
 
 
 def test_interesting_prefix(tmp_path):
@@ -40,7 +43,7 @@ def test_interesting_prefix(tmp_path):
     cov = {(('mod', 1), ('mod', 2))}
     saved, path = corpus.save_input(b"A", cov, "interesting")
     assert saved
-    assert os.path.basename(path).startswith("interesting-")
+    assert Path(tmp_path) / "interesting" in Path(path).parents
 
 
 def test_load_existing_coverage(tmp_path):


### PR DESCRIPTION
## Summary
- organize corpus entries in category subfolders
- traverse subdirectories when loading corpus files
- update corpus manager CLI to handle new layout
- adjust mutator corpus loading
- document directory layout change
- update tests for new paths

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e601863c83268c920fd3653680b2