### PR TITLE
Add edge execution counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ where these inputs are saved. Basic block transition coverage via breakpoints is
 enabled.
 Provide `--seed-dir` to load an initial set of files as seeds.
 
+Coverage data now records how many times each edge is executed. The
+tracing loop increments a counter for every observed transition between
+basic blocks. Tracking counts per edge provides more context than basic
+block counts and still allows computing block execution frequency by
+summing the counts of outgoing edges. Per-edge counting keeps the data
+structure small while retaining useful precision.
+
 Each saved input is keyed by a hash of the coverage it produced. Samples are
 written as JSON files containing the executed basic block transitions, the input
 bytes (base64 encoded), and optionally the first N bytes of stdout/stderr from

--- a/src/fz/__main__.py
+++ b/src/fz/__main__.py
@@ -33,7 +33,7 @@ class Fuzzer:
 
     def _run_once(self, target, data, timeout, file_input=False, network=None, libs=None, qemu_user=None, gdb_port=1234, arch=None):
         """Execute target once and record coverage."""
-        coverage_set = set()
+        coverage_set = {}
         if network:
             coverage_set, crashed, timed_out, exit_code, stdout_data, stderr_data = network.run(
                 target, data, timeout, self.corpus.output_bytes, libs=libs
@@ -66,7 +66,7 @@ class Fuzzer:
 
         saved, path = self.corpus.save_input(
             data,
-            coverage_set,
+            set(coverage_set.keys()),
             category,
             stdout_data,
             stderr_data,
@@ -137,7 +137,7 @@ class Fuzzer:
                     gdb_port=args.gdb_port,
                     arch=args.arch,
                 )
-                mutator.record_result(data, coverage_set, interesting)
+                mutator.record_result(data, set(coverage_set.keys()), interesting)
                 if interesting:
                     saved += 1
                     if saved_counter is not None:

--- a/src/fz/coverage/__init__.py
+++ b/src/fz/coverage/__init__.py
@@ -9,7 +9,7 @@ import platform
 
 from .collector import CoverageCollector, LinuxCollector, MacOSCollector
 from .gdb_collector import QemuGdbCollector
-from .cfg import ControlFlowGraph
+from .cfg import ControlFlowGraph, EdgeCoverage
 from .utils import get_possible_edges
 from .visualize import main as visualize_cfg
 
@@ -29,6 +29,7 @@ __all__ = [
     "CoverageCollector",
     "get_collector",
     "ControlFlowGraph",
+    "EdgeCoverage",
     "get_possible_edges",
     "visualize_cfg",
     "QemuGdbCollector",

--- a/src/fz/coverage/cfg.py
+++ b/src/fz/coverage/cfg.py
@@ -1,9 +1,10 @@
 import os
-from typing import Dict, Iterable, Set, Tuple
+from typing import Dict, Iterable, Set, Tuple, Mapping
 
 
 Address = Tuple[str, int]
 Edge = Tuple[Address, Address]
+EdgeCoverage = Dict[Edge, int]
 
 
 class ControlFlowGraph:
@@ -18,19 +19,23 @@ class ControlFlowGraph:
         # edges discovered via static analysis
         self.possible_edges: Set[Edge] = set()
 
-    def add_edges(self, edges: Iterable[Edge]) -> None:
-        """Add executed edges to the graph and increment their counters.
+    def add_edges(self, edges: Iterable[Edge] | Mapping[Edge, int]) -> None:
+        """Add executed edges and increment their counters.
 
         Parameters
         ----------
         edges:
-            Iterable of ``(src, dst)`` edges that were observed during
-            execution.
+            Either an iterable of ``(src, dst)`` edges or a mapping of
+            edges to execution counts.
         """
-        for src, dst in edges:
+        if isinstance(edges, Mapping):
+            items = edges.items()
+        else:
+            items = ((e, 1) for e in edges)
+        for (src, dst), count in items:
             self.adj.setdefault(src, set()).add(dst)
             key = (src, dst)
-            self.edge_counts[key] = self.edge_counts.get(key, 0) + 1
+            self.edge_counts[key] = self.edge_counts.get(key, 0) + count
 
     def add_possible_edges(self, edges: Iterable[Edge]) -> None:
         """Record statically discovered edges without incrementing counts.

--- a/src/fz/harness/network.py
+++ b/src/fz/harness/network.py
@@ -41,7 +41,7 @@ class NetworkHarness:
         Returns
         -------
         tuple
-            ``(coverage_set, crashed, timed_out, exit_code, stdout, stderr)``
+            ``(coverage_map, crashed, timed_out, exit_code, stdout, stderr)``
         """
         logging.debug("Launching network target: %s", target)
         stdout_file = tempfile.TemporaryFile()

--- a/src/fz/harness/preload/__init__.py
+++ b/src/fz/harness/preload/__init__.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Optional, Tuple, Set
+from typing import Optional, Tuple
 
 from ...runner.target import run_target
 
@@ -17,13 +17,13 @@ class PreloadHarness:
         timeout: float,
         output_bytes: int = 0,
         libs: Optional[list[str]] = None,
-    ) -> Tuple[Set[tuple], bool, bool, int | None, bytes, bytes]:
+    ) -> Tuple[dict[tuple, int], bool, bool, int | None, bytes, bytes]:
         """Execute *target* under LD_PRELOAD and collect coverage.
 
         Returns
         -------
         tuple
-            ``(coverage_set, crashed, timed_out, exit_code, stdout, stderr)``
+            ``(coverage_map, crashed, timed_out, exit_code, stdout, stderr)``
         """
         env = os.environ.copy()
         var = "DYLD_INSERT_LIBRARIES" if sys.platform == "darwin" else "LD_PRELOAD"

--- a/src/fz/runner/target.py
+++ b/src/fz/runner/target.py
@@ -6,7 +6,7 @@ import subprocess
 import tempfile
 from typing import Set, Tuple, Optional
 
-from fz.coverage.cfg import Edge
+from fz.coverage.cfg import Edge, EdgeCoverage
 
 from fz import coverage
 
@@ -26,7 +26,7 @@ def run_target(
     arch: Optional[str] = None,
     env: Optional[dict[str, str]] = None,
 ) -> Tuple[
-    Set[Edge],
+    EdgeCoverage,
     bool,
     bool,
     int | None,
@@ -37,10 +37,10 @@ def run_target(
 
     Returns
     -------
-    Set[Edge], bool, bool, int | None, bytes, bytes
-        ``(coverage_set, crashed, timed_out, exit_code, stdout, stderr)``
+    EdgeCoverage, bool, bool, int | None, bytes, bytes
+        ``(coverage_map, crashed, timed_out, exit_code, stdout, stderr)``
     """
-    coverage_set: Set[Edge] = set()
+    coverage_set: EdgeCoverage = {}
     exit_code: int | None = None
     capture_output = output_bytes > 0
     if capture_output:
@@ -118,12 +118,12 @@ def run_target(
             logging.debug(
                 "Process %d exited before coverage collection", proc.pid
             )
-            coverage_set = set()
+            coverage_set = {}
         except OSError as e:
             logging.debug(
                 "Failed to collect coverage from pid %d: %s", proc.pid, e
             )
-            coverage_set = set()
+            coverage_set = {}
 
         crashed = False
         timed_out = False

--- a/tests/coverage/test_collectors.py
+++ b/tests/coverage/test_collectors.py
@@ -61,7 +61,7 @@ def test_linux_collector(monkeypatch, tiny_binary):
     monkeypatch.setattr(LinuxCollector, "_get_image_base", lambda self, pid, exe: 0)
 
     edges = collector.collect_coverage(1234, exe=exe, already_traced=True)
-    assert edges == {((exe, blocks[0]), (exe, blocks[1]))}
+    assert edges == {((exe, blocks[0]), (exe, blocks[1])): 1}
 
 
 def test_macos_collector(monkeypatch, tiny_binary):
@@ -83,7 +83,7 @@ def test_macos_collector(monkeypatch, tiny_binary):
     monkeypatch.setattr(MacOSCollector, "_get_image_base", lambda self, pid, exe: 0)
 
     edges = collector.collect_coverage(1234, exe=exe, already_traced=True)
-    assert edges == {((exe, blocks[0]), (exe, blocks[1]))}
+    assert edges == {((exe, blocks[0]), (exe, blocks[1])): 1}
 
     with pytest.raises(RuntimeError):
         collector.collect_coverage(1234, exe=None, already_traced=True)
@@ -117,7 +117,7 @@ def test_collect_coverage_with_library(monkeypatch, tiny_binary):
 
     edges = collector.collect_coverage(1234, exe=exe, libs=["libmagic.so"], already_traced=True)
     assert called["name"] == "libmagic.so"
-    assert edges == {((exe, blocks[0]), (exe, blocks[1]))}
+    assert edges == {((exe, blocks[0]), (exe, blocks[1])): 1}
 
 
 def test_find_library_symlink(monkeypatch):

--- a/tests/harness/test_preload.py
+++ b/tests/harness/test_preload.py
@@ -37,7 +37,7 @@ def test_preload_harness(tmp_path):
     cov, crashed, to, rc, out, err = harness.run(str(target), b"ping", 1.0, output_bytes=10)
     assert not to
     assert isinstance(rc, int)
-    assert isinstance(cov, set)
+    assert isinstance(cov, dict)
     cov, crashed, to, rc, out, err = harness.run(str(target), b"OVERFLOW:AAAAAAAA", 1.0)
     assert not crashed
     assert rc == 0

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -16,12 +16,12 @@ def test_run_target_no_tempfile(monkeypatch):
 
     class DummyCollector:
         def collect_coverage(self, *args, **kwargs):
-            return set()
+            return {}
 
     monkeypatch.setattr(coverage, "get_collector", lambda: DummyCollector())
 
     cov, crashed, to, rc, out, err = run_target("/usr/bin/true", b"", 1.0, output_bytes=0)
-    assert cov == set()
+    assert cov == {}
     assert calls["count"] == 0
     assert out == b""
     assert err == b""


### PR DESCRIPTION
## Summary
- track how many times each edge executes
- support edge count mappings in `ControlFlowGraph`
- update collectors and harnesses to report counts
- update CLI and tests to handle new coverage map
- document edge count rationale

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e8122ef48326a6644a6a91211bc8