### PR TITLE
Auto detect cross-arch targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This phase builds the foundational framework for targeting and monitoring applic
 
   - [ ] Libc Variants: Start with statically compiled binaries, then expand to handle dynamically linked targets using glibc, uclibc, and musl.
 
-  - [x] Emulation: Basic qemu-user integration via a GDB-based collector enables cross-architecture fuzzing.
+  - [x] Emulation: Automatic architecture detection launches the appropriate qemu-user when needed for cross-architecture fuzzing.
 
 - Execution Model
 
@@ -160,11 +160,9 @@ To run multiple fuzzing processes concurrently, use `--parallel`:
 python3 -m fz --target /path/to/binary --iterations 100 --parallel 4
 ```
 
-To fuzz a binary for another architecture using `qemu-user`, provide the emulator path with `--qemu-user` and specify the architecture:
-
-```bash
-python3 -m fz --target ./target_arm64 --qemu-user qemu-aarch64 --arch arm64
-```
+To fuzz a binary built for a different architecture, simply point `--target` at
+the cross-compiled binary. If a matching `qemu-user` emulator is installed it
+will be invoked automatically.
 
 Coverage is gathered automatically using `ptrace`. The addresses recorded are
 normalized to the binary's load base so identical inputs yield identical

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,14 +12,9 @@ For each example target located in a subdirectory (e.g., `examples/<target_name>
 This script will compile the target program and then run the main fuzzer against it. Specific parameters like input size are configured within each `fuzz.sh` script.
 
 Each Makefile now builds both the native binary and an `*_arm64` version using
-`aarch64-linux-gnu-gcc`. The extra binary allows cross-architecture fuzzing via
-`qemu-user`.
-
-To run an ARM64 example under emulation use the new `--qemu-user` option:
-
-```bash
-python3 ../../fz --target ./target1_arm64 --qemu-user qemu-aarch64 --arch arm64
-```
+`aarch64-linux-gnu-gcc`. When the fuzzer detects that the target binary is for a
+different architecture, it automatically searches for the matching
+`qemu-user` emulator and runs the program under emulation if available.
 
 ---
 

--- a/src/fz/__main__.py
+++ b/src/fz/__main__.py
@@ -31,7 +31,7 @@ class Fuzzer:
         self.cfg = ControlFlowGraph()
         self.minimize = minimize
 
-    def _run_once(self, target, data, timeout, file_input=False, network=None, libs=None, qemu_user=None, gdb_port=1234, arch=None):
+    def _run_once(self, target, data, timeout, file_input=False, network=None, libs=None, gdb_port=1234):
         """Execute target once and record coverage."""
         coverage_set = {}
         if network:
@@ -49,9 +49,7 @@ class Fuzzer:
                 file_input=file_input,
                 output_bytes=self.corpus.output_bytes,
                 libs=libs,
-                qemu_user=qemu_user,
                 gdb_port=gdb_port,
-                arch=arch,
                 env=None,
             )
             logging.debug(
@@ -133,9 +131,7 @@ class Fuzzer:
                     args.file_input,
                     harness,
                     args.instrument_libs,
-                    qemu_user=args.qemu_user,
                     gdb_port=args.gdb_port,
-                    arch=args.arch,
                 )
                 mutator.record_result(data, set(coverage_set.keys()), interesting)
                 if interesting:
@@ -340,19 +336,10 @@ def parse_args():
         help="Names of shared libraries to instrument for coverage",
     )
     parser.add_argument(
-        "--qemu-user",
-        help="Path to qemu-user binary for emulation",
-    )
-    parser.add_argument(
         "--gdb-port",
         type=int,
         default=1234,
         help="GDB port for qemu-user",
-    )
-    parser.add_argument(
-        "--arch",
-        default="x86_64",
-        help="Target architecture when using qemu-user",
     )
     mode_group = parser.add_mutually_exclusive_group()
     mode_group.add_argument(


### PR DESCRIPTION
## Summary
- detect target architecture and use qemu-user automatically
- remove `--arch` and `--qemu-user` options
- update README docs for automatic qemu handling
- update example README instructions

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ee1c8e448326a7573eaeae6092a9