### PR TITLE
Initialize corpus directories

### DIFF
--- a/src/fz/corpus/corpus.py
+++ b/src/fz/corpus/corpus.py
@@ -18,6 +18,8 @@ class Corpus:
     def __init__(self, directory: str = "corpus", output_bytes: int = 0):
         self.directory = directory
         os.makedirs(directory, exist_ok=True)
+        for sub in ("interesting", "crash", "timeout"):
+            os.makedirs(os.path.join(directory, sub), exist_ok=True)
         self.coverage = set()
         self.coverage_hashes = set()
         self.output_bytes = output_bytes
@@ -79,7 +81,6 @@ class Corpus:
         cov_hash = hashlib.sha1(hash_input).hexdigest()
         filename = cov_hash
         category_dir = os.path.join(self.directory, category)
-        os.makedirs(category_dir, exist_ok=True)
         path = os.path.join(category_dir, f"{filename}.json")
 
         existing = [

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -4,6 +4,12 @@ from fz.corpus.corpus import Corpus
 from fz.corpus import decode_coverage
 
 
+def test_output_dirs_created(tmp_path):
+    Corpus(str(tmp_path))
+    for name in ("interesting", "crash", "timeout"):
+        assert (tmp_path / name).is_dir()
+
+
 def test_crash_saved_on_unique_coverage(tmp_path):
     corpus = Corpus(str(tmp_path))
     cov1 = {(('mod', 1), ('mod', 2))}


### PR DESCRIPTION
## Summary
- ensure the `Corpus` creates `interesting`, `crash`, and `timeout` folders during initialization
- drop redundant directory creation in `save_input`

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863ee94333c83269fdac3af48dd216a