### PR TITLE
Preserve edge counts when hashing coverage

### DIFF
--- a/src/fz/__main__.py
+++ b/src/fz/__main__.py
@@ -64,7 +64,7 @@ class Fuzzer:
 
         saved, path = self.corpus.save_input(
             data,
-            set(coverage_set.keys()),
+            coverage_set,
             category,
             stdout_data,
             stderr_data,

--- a/src/fz/corpus/mutator.py
+++ b/src/fz/corpus/mutator.py
@@ -58,9 +58,9 @@ class Mutator:
                     with open(path, "r") as f:
                         record = json.load(f)
                     data = base64.b64decode(record.get("data", ""))
-                    coverage = list(decode_coverage(record.get("coverage", [])))
+                    coverage_map = decode_coverage(record.get("coverage", []))
                     self.seeds.append(data)
-                    self.seed_edges.append(coverage)
+                    self.seed_edges.append(list(coverage_map.keys()))
                     if data:
                         self.non_empty_seeds.append(data)
                 except Exception:

--- a/src/fz/corpus/utils.py
+++ b/src/fz/corpus/utils.py
@@ -1,16 +1,20 @@
-from typing import Iterable, Set
+from typing import Iterable
 
-from fz.coverage.cfg import Edge
+from fz.coverage.cfg import Edge, EdgeCoverage
 
 
-def decode_coverage(coverage: Iterable) -> Set[Edge]:
-    """Return ``coverage`` decoded as a set of edges."""
-    edges: Set[Edge] = set()
+def decode_coverage(coverage: Iterable) -> EdgeCoverage:
+    """Return ``coverage`` decoded as an :class:`EdgeCoverage` mapping."""
+    edges: EdgeCoverage = {}
     for c in coverage or []:
         if (
             isinstance(c, (list, tuple))
-            and len(c) == 2
-            and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in c)
+            and len(c) >= 2
+            and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in c[:2])
         ):
-            edges.add((tuple(c[0]), tuple(c[1])))
+            edge = (tuple(c[0]), tuple(c[1]))
+            count = 1
+            if len(c) >= 3 and isinstance(c[2], int):
+                count = c[2]
+            edges[edge] = count
     return edges

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -12,7 +12,7 @@ def test_output_dirs_created(tmp_path):
 
 def test_crash_saved_on_unique_coverage(tmp_path):
     corpus = Corpus(str(tmp_path))
-    cov1 = {(('mod', 1), ('mod', 2))}
+    cov1 = {(("mod", 1), ("mod", 2)): 1}
     saved, path = corpus.save_input(b"A", cov1, "crash")
     assert saved
     assert os.path.exists(path)
@@ -27,26 +27,35 @@ def test_crash_saved_on_unique_coverage(tmp_path):
     assert path is None
     assert len(list(crash_dir.iterdir())) == 1
 
-    # New combination introduces an additional edge
-    cov2 = {(('mod', 1), ('mod', 2)), (('mod', 3), ('mod', 4))}
-    saved, path = corpus.save_input(b"C", cov2, "crash")
+    # Same edges with different counts should be unique
+    cov1_more = {(("mod", 1), ("mod", 2)): 2}
+    saved, path = corpus.save_input(b"B2", cov1_more, "crash")
     assert saved
-    assert os.path.exists(path)
-    assert crash_dir in Path(path).parents
     assert len(list(crash_dir.iterdir())) == 2
 
-    # Unique set composed of previously seen edges should also be saved
-    cov3 = {(('mod', 3), ('mod', 4))}
-    saved, path = corpus.save_input(b"D", cov3, "crash")
+    # New combination introduces an additional edge
+    cov2 = {
+        (("mod", 1), ("mod", 2)): 1,
+        (("mod", 3), ("mod", 4)): 1,
+    }
+    saved, path = corpus.save_input(b"C", cov2, "crash")
     assert saved
     assert os.path.exists(path)
     assert crash_dir in Path(path).parents
     assert len(list(crash_dir.iterdir())) == 3
 
+    # Unique set composed of previously seen edges should also be saved
+    cov3 = {(("mod", 3), ("mod", 4)): 1}
+    saved, path = corpus.save_input(b"D", cov3, "crash")
+    assert saved
+    assert os.path.exists(path)
+    assert crash_dir in Path(path).parents
+    assert len(list(crash_dir.iterdir())) == 4
+
 
 def test_interesting_prefix(tmp_path):
     corpus = Corpus(str(tmp_path))
-    cov = {(('mod', 1), ('mod', 2))}
+    cov = {(("mod", 1), ("mod", 2)): 1}
     saved, path = corpus.save_input(b"A", cov, "interesting")
     assert saved
     assert Path(tmp_path) / "interesting" in Path(path).parents
@@ -54,7 +63,7 @@ def test_interesting_prefix(tmp_path):
 
 def test_load_existing_coverage(tmp_path):
     corpus = Corpus(str(tmp_path))
-    cov = {(('mod', 1), ('mod', 2))}
+    cov = {(("mod", 1), ("mod", 2)): 1}
     saved, path = corpus.save_input(b"A", cov)
     assert saved
 
@@ -66,10 +75,13 @@ def test_load_existing_coverage(tmp_path):
 
 
 def test_decode_coverage_helper():
-    cov_list = [[["mod", 1], ["mod", 2]], [["mod", 3], ["mod", 4]]]
+    cov_list = [
+        [["mod", 1], ["mod", 2], 2],
+        [["mod", 3], ["mod", 4], 1],
+    ]
     edges = decode_coverage(cov_list)
     assert edges == {
-        (("mod", 1), ("mod", 2)),
-        (("mod", 3), ("mod", 4)),
+        (("mod", 1), ("mod", 2)): 2,
+        (("mod", 3), ("mod", 4)): 1,
     }
 

--- a/tests/test_mutator.py
+++ b/tests/test_mutator.py
@@ -15,8 +15,11 @@ def test_weights_update_on_new_edges(tmp_path):
     corpus_dir = str(tmp_path)
     corpus = Corpus(corpus_dir)
 
-    cov1 = {(('mod', 1), ('mod', 2)), (('mod', 2), ('mod', 3))}
-    cov2 = {(('mod', 3), ('mod', 4))}
+    cov1 = {
+        (("mod", 1), ("mod", 2)): 1,
+        (("mod", 2), ("mod", 3)): 1,
+    }
+    cov2 = {(("mod", 3), ("mod", 4)): 1}
 
     corpus.save_input(b'A', cov1)
     corpus.save_input(b'B', cov2)
@@ -26,10 +29,10 @@ def test_weights_update_on_new_edges(tmp_path):
     assert sorted(m.weights) == [1, 1, 2]
 
     cfg.add_edges(cov1)
-    m.record_result(b'A', cov1, interesting=False)
+    m.record_result(b'A', set(cov1.keys()), interesting=False)
     assert sorted(m.weights) == [1, 1, 2]
 
-    new_cov = {(('mod', 4), ('mod', 5))}
+    new_cov = {(("mod", 4), ("mod", 5))}
     cfg.add_edges(new_cov)
     m.record_result(b'C', new_cov, interesting=True)
 
@@ -40,7 +43,7 @@ def test_non_empty_seed_tracking(tmp_path):
     corpus_dir = str(tmp_path)
     corpus = Corpus(corpus_dir)
 
-    cov = {(('mod', 1), ('mod', 2))}
+    cov = {(("mod", 1), ("mod", 2)): 1}
     corpus.save_input(b'A', cov)
 
     m = Mutator(corpus_dir=corpus_dir, input_size=8)
@@ -48,9 +51,9 @@ def test_non_empty_seed_tracking(tmp_path):
     assert b"" in m.seeds
     assert m.non_empty_seeds == [b"A"]
 
-    m.record_result(b"B", cov, interesting=True)
+    m.record_result(b"B", set(cov.keys()), interesting=True)
     assert b"B" in m.non_empty_seeds
-    m.record_result(b"C", cov, interesting=False)
+    m.record_result(b"C", set(cov.keys()), interesting=False)
     assert b"C" not in m.non_empty_seeds
 
 


### PR DESCRIPTION
## Summary
- store execution counts for each edge in saved corpus entries
- include execution counts when computing coverage hashes
- adjust corpus utilities to decode edge counts
- keep seed weights accurate with new coverage format
- update tests for new EdgeCoverage semantics

## Testing
- `python3 -m compileall src`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 1`
- `python3 -m fz --file-input --corpus-dir ./corpus/ --target /usr/bin/file --iterations 2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f738593c8326bd6ff0832b240df7